### PR TITLE
Fix homepage upcoming events

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -49,32 +49,35 @@ templateEngineOverride: njk
       <a href="/events/" class="btn-secondary">View All Events</a>
     </div>
 
-    {% if upcoming.length > 0 %}
-    <div class="events-grid home-events-grid">
-      {% for e in upcoming %}
-      {% if loop.index0 < 3 %}
-      <a href="/events/{{ e.slug }}/" class="event-card">
-        <div class="event-card-header">
-          <div class="event-card-date"><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></span> {{ e.date }}</div>
-          <h3 class="event-card-title">{{ e.title }}</h3>
-        </div>
-        <div class="event-card-body">
-          <div class="event-card-location"><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 1118 0z"/><circle cx="12" cy="10" r="3"/></svg></span> {{ e.location }}</div>
-        </div>
-        <div class="event-card-footer">
-          <span class="event-card-btn">View Event</span>
-        </div>
-      </a>
+    <div id="home-events-list">
+      {% if upcoming.length > 0 %}
+      <div class="events-grid home-events-grid">
+        {% for e in upcoming %}
+        {% if loop.index0 < 3 %}
+        <a href="/events/{{ e.slug }}/" class="event-card">
+          <div class="event-card-header">
+            <div class="event-card-date"><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></span> {{ e.date }}</div>
+            <h3 class="event-card-title">{{ e.title }}</h3>
+          </div>
+          <div class="event-card-body">
+            <div class="event-card-location"><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 1118 0z"/><circle cx="12" cy="10" r="3"/></svg></span> {{ e.location }}</div>
+          </div>
+          <div class="event-card-footer">
+            <span class="event-card-btn">View Event</span>
+          </div>
+        </a>
+        {% endif %}
+        {% endfor %}
+      </div>
+      {% else %}
+      <div class="card events-empty">
+        <h3>Events Coming Soon</h3>
+        <p>We are planning future community events. Explore local chapters to stay connected and get notified when new events are announced.</p>
+        <a href="/chapters/" class="btn-primary">Find a Chapter</a>
+      </div>
       {% endif %}
-      {% endfor %}
     </div>
-    {% else %}
-    <div class="card events-empty">
-      <h3>Events Coming Soon</h3>
-      <p>We are planning future community events. Explore local chapters to stay connected and get notified when new events are announced.</p>
-      <a href="/chapters/" class="btn-primary">Find a Chapter</a>
-    </div>
-    {% endif %}
+    <script src="/js/events-list.js?v={{ cacheBust }}"></script>
   </section>
 
   <section class="home-section home-section--mission" aria-labelledby="mission-heading">

--- a/src/js/events-list.js
+++ b/src/js/events-list.js
@@ -1,9 +1,14 @@
 (async function() {
   var container = document.getElementById('events-list');
+  var isHomepagePreview = false;
+  if (!container) {
+    container = document.getElementById('home-events-list');
+    isHomepagePreview = !!container;
+  }
   if (!container) return;
   var hasServerRenderedEvents = !!container.querySelector('.event-card, .events-empty');
   try {
-    var res = await fetch('/api/getEvent?action=list');
+    var res = await GSC.fetch('/api/getEvent?action=list');
     if (!res.ok) throw new Error('Failed to load events');
     var events = await res.json();
 
@@ -21,6 +26,14 @@
     }).sort(function(a, b) { return new Date(b.date) - new Date(a.date); });
 
     var html = '';
+
+    if (isHomepagePreview) {
+      html = upcoming.length
+        ? '<div class="events-grid home-events-grid">' + upcoming.slice(0, 3).map(function(e) { return renderEventCard(e); }).join('') + '</div>'
+        : '<div class="card events-empty"><h3>Events Coming Soon</h3><p>We are planning future community events. Explore local chapters to stay connected and get notified when new events are announced.</p><a href="/chapters/" class="btn-primary">Find a Chapter</a></div>';
+      container.innerHTML = html;
+      return;
+    }
 
     if (upcoming.length) {
       html += '<h2 class="section-title">Upcoming Events</h2>';


### PR DESCRIPTION
## Summary
- Adds a homepage events container that can be hydrated client-side.
- Reuses the existing events list loader for the homepage preview, limited to the next three upcoming events.
- Uses /api/getEvent?action=list at runtime so the homepage is not stuck with an empty build-time fallback.

## Validation
- `npm run build`
- `npm run test:e2e -- e2e/public-pages.spec.js`
- Simulated empty server-rendered homepage and confirmed the client loader renders upcoming events in date order.