### PR TITLE
Fix delete chapter workflow YAML

### DIFF
--- a/.github/workflows/delete-chapter.yml
+++ b/.github/workflows/delete-chapter.yml
@@ -19,9 +19,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
-        with:
           ref: main
+          fetch-depth: 0
 
       - name: Verify chapter exists
         env:


### PR DESCRIPTION
## Summary
- Removes the duplicate `with` block from the checkout step in `delete-chapter.yml`.
- Restores the workflow to valid YAML so GitHub should stop creating failed push runs with no jobs.

## Validation
- `git diff --check`