### PR TITLE
Fix event team recognition

### DIFF
--- a/api/src/functions/getEvent.js
+++ b/api/src/functions/getEvent.js
@@ -94,15 +94,28 @@ module.exports = async function (request, context) {
 
     const registrationCount = await countRegistrations(event.rowKey);
 
-    // Fetch volunteers (public-safe info only)
+    // Fetch public recognition data (public-safe info only)
     let volunteers = [];
     try {
-      const volRegs = await getRegistrationsByRole(event.rowKey, 'volunteer');
-      volunteers = volRegs.map(v => ({
-        name: v.fullName,
-        company: v.company || ''
-      }));
-    } catch { /* non-critical */ }
+      const [organiserRegs, volunteerRegs] = await Promise.all([
+        getRegistrationsByRole(event.rowKey, 'organiser'),
+        getRegistrationsByRole(event.rowKey, 'volunteer')
+      ]);
+      volunteers = [
+        ...organiserRegs.map(v => ({
+          name: v.fullName,
+          company: v.company || '',
+          role: 'organiser'
+        })),
+        ...volunteerRegs.map(v => ({
+          name: v.fullName,
+          company: v.company || '',
+          role: 'volunteer'
+        }))
+      ].filter(v => v.name);
+    } catch (error) {
+      context.log(`getEvent recognition lookup error: ${error.message}`);
+    }
 
     return {
       status: 200,

--- a/api/tests/functions.test.js
+++ b/api/tests/functions.test.js
@@ -150,6 +150,40 @@ describe('getEvent function', () => {
     expect(body.registrationCount).toBe(42);
     expect(body.registrationCap).toBe(100);
   });
+
+  test('returns public organiser and volunteer recognition details', async () => {
+    storage.getEventBySlug.mockResolvedValueOnce({
+      rowKey: 'ev-1',
+      title: 'Test Event',
+      slug: 'test-event',
+      chapterSlug: 'perth',
+      date: '2026-05-15',
+      endDate: '',
+      location: 'Perth',
+      description: 'A test event',
+      sessionizeApiId: '',
+      registrationCap: 100,
+      status: 'published'
+    });
+    storage.getRegistrationsByRole
+      .mockResolvedValueOnce([
+        { fullName: 'Olivia Organiser', company: 'GSC', email: 'olivia@example.com', ticketCode: 'ORG123' }
+      ])
+      .mockResolvedValueOnce([
+        { fullName: 'Victor Volunteer', company: 'Community Co', email: 'victor@example.com', ticketCode: 'VOL123' }
+      ]);
+
+    const req = { ...makeRequest('GET'), url: 'https://example.com/api/getEvent?slug=test-event' };
+    const res = await getEvent(req, context);
+    expect(res.status).toBe(200);
+
+    expect(storage.getRegistrationsByRole).toHaveBeenCalledWith('ev-1', 'organiser');
+    expect(storage.getRegistrationsByRole).toHaveBeenCalledWith('ev-1', 'volunteer');
+    expect(JSON.parse(res.body).volunteers).toEqual([
+      { name: 'Olivia Organiser', company: 'GSC', role: 'organiser' },
+      { name: 'Victor Volunteer', company: 'Community Co', role: 'volunteer' }
+    ]);
+  });
 });
 
 describe('checkIn function', () => {

--- a/src/_includes/layouts/event.njk
+++ b/src/_includes/layouts/event.njk
@@ -38,9 +38,12 @@ layout: base.njk
   <h2>About This Event</h2>
   <div id="event-description" class="event-description">{{ description }}</div>
 
-  <div id="volunteer-cards" class="volunteer-cards is-hidden">
-    <h3>Event Volunteers</h3>
-  </div>
+  <section id="volunteer-cards" class="recognition-section is-hidden" aria-labelledby="recognition-heading">
+    <p class="section-kicker">Community recognition</p>
+    <h2 id="recognition-heading">Event Team</h2>
+    <p class="recognition-intro">Thank you to the people helping make this event possible.</p>
+    <div id="recognition-groups" class="recognition-groups"></div>
+  </section>
 
   {% if sessionizeApiId %}
   <h2>Agenda</h2>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1159,23 +1159,47 @@ td {
   font-size: var(--text-sm);
 }
 
-/* Volunteer cards on event page */
+/* Recognition cards on event page */
+.recognition-section {
+  margin: var(--space-2xl) 0;
+  padding: var(--space-xl);
+  background: linear-gradient(135deg, rgba(0, 120, 160, 0.08), rgba(255, 140, 66, 0.08));
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+}
+.recognition-section h2 {
+  margin-top: 0;
+}
+.recognition-intro {
+  max-width: 42rem;
+  color: var(--color-text-muted);
+}
+.recognition-groups {
+  display: grid;
+  gap: var(--space-xl);
+  margin-top: var(--space-xl);
+}
+.recognition-group h3 {
+  margin-bottom: var(--space-md);
+}
 .volunteer-cards {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: var(--space-lg);
-  margin-bottom: var(--space-2xl);
 }
 .volunteer-card {
-  background: var(--color-surface-soft);
+  position: relative;
+  background: var(--color-surface);
   border: 1px solid var(--color-border-subtle);
   border-radius: var(--radius-md);
-  padding: var(--space-lg) var(--space-xl);
-  text-align: center;
-  min-width: 140px;
+  padding: var(--space-xl);
+  box-shadow: var(--shadow-sm);
+}
+.volunteer-card .role-badge {
+  margin-bottom: var(--space-md);
 }
 .volunteer-name {
-  font-weight: 600;
+  font-weight: 700;
   color: var(--color-primary-navy);
   margin-bottom: var(--space-xs);
 }

--- a/src/js/event-page.js
+++ b/src/js/event-page.js
@@ -71,21 +71,7 @@
               : GSC.esc(data.description);
           }
         }
-        // Render volunteer cards
-        if (data.volunteers && data.volunteers.length > 0) {
-          var volEl = document.getElementById('volunteer-cards');
-          if (volEl) {
-            var html = '';
-            data.volunteers.forEach(function(v) {
-              html += '<div class="volunteer-card">';
-              html += '<div class="volunteer-name">' + GSC.esc(v.name) + '</div>';
-              if (v.company) html += '<div class="volunteer-company">' + GSC.esc(v.company) + '</div>';
-              html += '</div>';
-            });
-            volEl.innerHTML = html;
-            volEl.style.display = 'flex';
-          }
-        }
+        renderRecognition(data.volunteers);
         // Load community partners
         if (data.id) { loadPartners(data.id); }
       })
@@ -93,6 +79,48 @@
         var el = document.getElementById('reg-count');
         if (el) el.textContent = '—';
       });
+  }
+
+  function renderRecognition(volunteers) {
+    var section = document.getElementById('volunteer-cards');
+    var groupsEl = document.getElementById('recognition-groups');
+    if (!section || !groupsEl || !volunteers || volunteers.length === 0) return;
+
+    var groups = {
+      organiser: [],
+      volunteer: []
+    };
+
+    volunteers.forEach(function(person) {
+      var role = person.role === 'organiser' ? 'organiser' : person.role === 'volunteer' ? 'volunteer' : '';
+      if (!role || !person.name) return;
+      groups[role].push(person);
+    });
+
+    var html = '';
+    html += renderRecognitionGroup('organiser', 'Organisers', groups.organiser);
+    html += renderRecognitionGroup('volunteer', 'Volunteers', groups.volunteer);
+
+    if (!html) return;
+    groupsEl.innerHTML = html;
+    section.classList.remove('is-hidden');
+  }
+
+  function renderRecognitionGroup(role, heading, people) {
+    if (!people || people.length === 0) return '';
+
+    var html = '<div class="recognition-group recognition-group--' + role + '">';
+    html += '<h3>' + heading + '</h3>';
+    html += '<div class="volunteer-cards">';
+    people.forEach(function(person) {
+      html += '<article class="volunteer-card">';
+      html += '<span class="role-badge role-badge--' + role + '">' + GSC.esc(role) + '</span>';
+      html += '<div class="volunteer-name">' + GSC.esc(person.name) + '</div>';
+      if (person.company) html += '<div class="volunteer-company">' + GSC.esc(person.company) + '</div>';
+      html += '</article>';
+    });
+    html += '</div></div>';
+    return html;
   }
 
   function loadPartners(eventId) {


### PR DESCRIPTION
## Summary
- Return public organiser and volunteer recognition details from getEvent
- Render a preserved Event Team section with clearly grouped organiser/volunteer cards
- Keep output XSS-safe via escaped client-side rendering and add API coverage

## Validation
- npm run build
- cd api && npm test -- --runInBand