### PR TITLE
Fix automation workflows blocked by branch protection via PR + auto-merge flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/delete-chapter.yml
+++ b/.github/workflows/delete-chapter.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: write
   actions: write
+  pull-requests: write
 
 jobs:
   delete-chapter:
@@ -21,7 +22,6 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.GH_PAT }}
 
       - name: Verify chapter exists
         env:
@@ -84,25 +84,68 @@ jobs:
           rm -rf "src/chapters/${SLUG}"
           echo "Deleted src/chapters/${SLUG}/"
 
-      - name: Commit and push
+      - name: Create branch and commit
+        id: commit
         env:
           SLUG: ${{ inputs.chapter_slug }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
+          if git diff --cached --quiet; then
+            echo "No changes"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          BRANCH="bot/delete-chapter-${SLUG}-${GITHUB_RUN_ID}"
+          git checkout -b "$BRANCH"
           git commit -m "Remove chapter page: ${SLUG}
 
           Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
-          git push origin HEAD:main
+          git push origin "$BRANCH"
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      # main is protected and requires the "Build & Test" check to pass. A PR
+      # opened with the default GITHUB_TOKEN won't auto-trigger that check
+      # (GitHub suppresses recursive triggers from the built-in token), so we
+      # kick it off explicitly, then let auto-merge complete once it passes.
+      - name: Open PR and wait for merge
+        if: steps.commit.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.commit.outputs.branch }}
+          SLUG: ${{ inputs.chapter_slug }}
+        run: |
+          gh pr create --base main --head "$BRANCH" \
+            --title "Remove chapter page: ${SLUG}" \
+            --body "Automated chapter deletion. Auto-merges once CI passes."
+          PR_NUMBER=$(gh pr view "$BRANCH" --json number -q .number)
+
+          gh workflow run ci.yml --ref "$BRANCH"
+          gh pr merge "$PR_NUMBER" --auto --squash
+
+          echo "Waiting for PR #$PR_NUMBER to merge..."
+          for i in $(seq 1 40); do
+            STATE=$(gh pr view "$PR_NUMBER" --json state -q .state)
+            if [ "$STATE" = "MERGED" ]; then
+              echo "✅ PR #$PR_NUMBER merged"
+              exit 0
+            fi
+            if [ "$STATE" = "CLOSED" ]; then
+              echo "::error::PR #$PR_NUMBER was closed without merging"
+              exit 1
+            fi
+            sleep 15
+          done
+          echo "::error::Timed out waiting for PR #$PR_NUMBER to merge (CI may have failed)"
+          exit 1
 
       - name: Deploy to production
-        env:
-          SLUG: ${{ github.event.client_payload.chapter_slug }}
         run: |
-          git fetch origin live-version-swa
+          git fetch origin main live-version-swa
           git checkout live-version-swa
-          git merge main --no-edit
+          git merge origin/main --no-edit
           git push origin live-version-swa
           echo "✅ Chapter deletion merged to live-version-swa"
 

--- a/.github/workflows/generate-chapter.yml
+++ b/.github/workflows/generate-chapter.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   actions: write
+  pull-requests: write
 
 jobs:
   generate-chapter:
@@ -16,7 +17,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_PAT }}
 
       - name: Geocode chapter location
         run: |
@@ -118,7 +118,8 @@ jobs:
 
           echo "Generated chapter page at ${TARGET_DIR}/index.md"
 
-      - name: Commit and push
+      - name: Create branch and commit
+        id: commit
         env:
           CITY: ${{ github.event.client_payload.chapter_city }}
           SLUG: ${{ github.event.client_payload.chapter_slug }}
@@ -126,19 +127,62 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add "src/chapters/${SLUG}/index.md"
+          if git diff --cached --quiet; then
+            echo "No changes"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          BRANCH="bot/chapter-${SLUG}-${GITHUB_RUN_ID}"
+          git checkout -b "$BRANCH"
           git commit -m "Add chapter page for ${CITY}
 
           Auto-generated from approved chapter application.
 
           Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
-          git pull --rebase origin main
-          git push origin HEAD:main
+          git push origin "$BRANCH"
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      # main is protected and requires the "Build & Test" check to pass. A PR
+      # opened with the default GITHUB_TOKEN won't auto-trigger that check
+      # (GitHub suppresses recursive triggers from the built-in token), so we
+      # kick it off explicitly, then let auto-merge complete once it passes.
+      - name: Open PR and wait for merge
+        if: steps.commit.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.commit.outputs.branch }}
+          CITY: ${{ github.event.client_payload.chapter_city }}
+        run: |
+          gh pr create --base main --head "$BRANCH" \
+            --title "Add chapter page for ${CITY}" \
+            --body "Automated chapter page generation. Auto-merges once CI passes."
+          PR_NUMBER=$(gh pr view "$BRANCH" --json number -q .number)
+
+          gh workflow run ci.yml --ref "$BRANCH"
+          gh pr merge "$PR_NUMBER" --auto --squash
+
+          echo "Waiting for PR #$PR_NUMBER to merge..."
+          for i in $(seq 1 40); do
+            STATE=$(gh pr view "$PR_NUMBER" --json state -q .state)
+            if [ "$STATE" = "MERGED" ]; then
+              echo "✅ PR #$PR_NUMBER merged"
+              exit 0
+            fi
+            if [ "$STATE" = "CLOSED" ]; then
+              echo "::error::PR #$PR_NUMBER was closed without merging"
+              exit 1
+            fi
+            sleep 15
+          done
+          echo "::error::Timed out waiting for PR #$PR_NUMBER to merge (CI may have failed)"
+          exit 1
 
       - name: Deploy to production
         run: |
-          git fetch origin live-version-swa
+          git fetch origin main live-version-swa
           git checkout live-version-swa
-          git merge main --no-edit
+          git merge origin/main --no-edit
           git push origin live-version-swa
           echo "✅ Chapter page merged to live-version-swa"
 

--- a/.github/workflows/generate-event.yml
+++ b/.github/workflows/generate-event.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   actions: write
+  pull-requests: write
 
 jobs:
   generate:
@@ -16,7 +17,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_PAT }}
 
       - name: Geocode event location
         run: |
@@ -101,16 +101,24 @@ jobs:
 
           echo "Generated event page at ${TARGET_DIR}/index.md"
 
-      - name: Commit and push
+      - name: Create branch and commit
+        id: commit
         env:
           EVENT_TITLE: ${{ github.event.client_payload.event_title }}
           EVENT_DATE: ${{ github.event.client_payload.event_date }}
           CHAPTER_SLUG: ${{ github.event.client_payload.chapter_slug }}
+          SLUG: ${{ github.event.client_payload.event_slug }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .
-          git diff --cached --quiet && echo "No changes" && exit 0
+          if git diff --cached --quiet; then
+            echo "No changes"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          BRANCH="bot/event-${SLUG}-${GITHUB_RUN_ID}"
+          git checkout -b "$BRANCH"
           git commit -m "Add event page: ${EVENT_TITLE}
 
           Event: ${EVENT_TITLE}
@@ -118,15 +126,50 @@ jobs:
           Chapter: ${CHAPTER_SLUG}
 
           Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
-          # Pull latest changes before pushing to avoid rejection
-          git pull --rebase origin main
-          git push origin HEAD:main
+          git push origin "$BRANCH"
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      # main is protected and requires the "Build & Test" check to pass. A PR
+      # opened with the default GITHUB_TOKEN won't auto-trigger that check
+      # (GitHub suppresses recursive triggers from the built-in token), so we
+      # kick it off explicitly, then let auto-merge complete once it passes.
+      - name: Open PR and wait for merge
+        if: steps.commit.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.commit.outputs.branch }}
+          EVENT_TITLE: ${{ github.event.client_payload.event_title }}
+        run: |
+          gh pr create --base main --head "$BRANCH" \
+            --title "Add event page: ${EVENT_TITLE}" \
+            --body "Automated event page generation. Auto-merges once CI passes."
+          PR_NUMBER=$(gh pr view "$BRANCH" --json number -q .number)
+
+          gh workflow run ci.yml --ref "$BRANCH"
+          gh pr merge "$PR_NUMBER" --auto --squash
+
+          echo "Waiting for PR #$PR_NUMBER to merge..."
+          for i in $(seq 1 40); do
+            STATE=$(gh pr view "$PR_NUMBER" --json state -q .state)
+            if [ "$STATE" = "MERGED" ]; then
+              echo "✅ PR #$PR_NUMBER merged"
+              exit 0
+            fi
+            if [ "$STATE" = "CLOSED" ]; then
+              echo "::error::PR #$PR_NUMBER was closed without merging"
+              exit 1
+            fi
+            sleep 15
+          done
+          echo "::error::Timed out waiting for PR #$PR_NUMBER to merge (CI may have failed)"
+          exit 1
 
       - name: Deploy to production
         run: |
-          git fetch origin live-version-swa
+          git fetch origin main live-version-swa
           git checkout live-version-swa
-          git merge main --no-edit
+          git merge origin/main --no-edit
           git push origin live-version-swa
           echo "✅ Event page merged to live-version-swa"
 


### PR DESCRIPTION
## Problem

PR #143 attempted to fix `generate-event.yml`, `generate-chapter.yml`, and `delete-chapter.yml` failing with `GH006: Protected branch update failed` (main requires the "Build & Test" status check) by switching to a `GH_PAT` secret for checkout/push.

That fix was incomplete and wouldn't have worked even if finished:
- The `GH_PAT` secret was never actually created in repo settings.
- `main`'s branch protection has `enforce_admins: true` — required status checks apply to *everyone*, including admins, on direct pushes. A PAT, regardless of whose account it belongs to, can't bypass this for a direct `git push` to a protected branch.

## Fix

Replaced direct pushes to `main` with a proper PR + auto-merge flow in all three automation workflows:

1. Commit generated content to a throwaway `bot/*` branch and push it
2. Open a PR against `main`
3. Explicitly trigger `ci.yml` (added a `workflow_dispatch` trigger) for that branch — GitHub suppresses auto-triggered checks for events created by the default `GITHUB_TOKEN`, so the required "Build & Test" check needs an explicit kick
4. Enable auto-merge (squash) and poll (~10 min timeout) until merged
5. Deploy step now merges `origin/main` (not stale local `main`) into `live-version-swa`

**No new secrets required** — everything runs on the default `GITHUB_TOKEN`. This respects branch protection properly rather than working around it, so it won't need revisiting if protection rules change later.

**Repo settings changed** (required for auto-merge): `allow_auto_merge` and `delete_branch_on_merge` enabled.

## Testing

- All 4 modified YAML files validated with `yaml.safe_load`.
- Not yet tested end-to-end against a real `repository_dispatch`/`workflow_dispatch` trigger — recommend a manual test run (e.g. trigger `delete-chapter.yml` against a test chapter, or a real event/chapter approval) before relying on this in production.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>