### PR TITLE
Fix remaining GH_PAT references and restore production deploy in automation workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/delete-chapter.yml
+++ b/.github/workflows/delete-chapter.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.GH_PAT }}
 
       - name: Verify chapter exists
         env:
@@ -101,10 +100,14 @@ jobs:
           git push origin "${BRANCH}"
           echo "BRANCH=${BRANCH}" >> "$GITHUB_ENV"
 
-      - name: Create PR and enable auto-merge
+      # main is protected and requires the "Build & Test" check to pass. A PR
+      # opened with the default GITHUB_TOKEN won't auto-trigger that check
+      # (GitHub suppresses recursive triggers from the built-in token), so we
+      # kick it off explicitly, then let auto-merge complete once it passes.
+      - name: Open PR and wait for merge
         if: env.BRANCH != ''
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLUG: ${{ inputs.chapter_slug }}
         run: |
           gh pr create \
@@ -114,5 +117,40 @@ jobs:
             --body "Removes the chapter page for \`${SLUG}\`.
 
           Triggered by \`delete-chapter\` workflow dispatch."
-          gh pr merge "${BRANCH}" --auto --squash || echo "::warning::Auto-merge could not be enabled — please merge the PR manually once CI passes"
-          echo "✅ PR created — will merge to main once CI passes"
+          PR_NUMBER=$(gh pr view "${BRANCH}" --json number -q .number)
+
+          gh workflow run ci.yml --ref "${BRANCH}"
+          gh pr merge "$PR_NUMBER" --auto --squash
+
+          echo "Waiting for PR #$PR_NUMBER to merge..."
+          for i in $(seq 1 40); do
+            STATE=$(gh pr view "$PR_NUMBER" --json state -q .state)
+            if [ "$STATE" = "MERGED" ]; then
+              echo "✅ PR #$PR_NUMBER merged"
+              exit 0
+            fi
+            if [ "$STATE" = "CLOSED" ]; then
+              echo "::error::PR #$PR_NUMBER was closed without merging"
+              exit 1
+            fi
+            sleep 15
+          done
+          echo "::error::Timed out waiting for PR #$PR_NUMBER to merge (CI may have failed)"
+          exit 1
+
+      - name: Deploy to production
+        if: env.BRANCH != ''
+        run: |
+          git fetch origin main live-version-swa
+          git checkout live-version-swa
+          git merge origin/main --no-edit
+          git push origin live-version-swa
+          echo "✅ Chapter deletion merged to live-version-swa"
+
+      - name: Trigger SWA deploy
+        if: env.BRANCH != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run azure-static-web-apps-lively-desert-0f1f18c10.yml --ref live-version-swa
+          echo "✅ SWA deploy triggered"

--- a/.github/workflows/generate-chapter.yml
+++ b/.github/workflows/generate-chapter.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_PAT }}
 
       - name: Geocode chapter location
         run: |
@@ -140,10 +139,14 @@ jobs:
           git push origin "${BRANCH}"
           echo "BRANCH=${BRANCH}" >> "$GITHUB_ENV"
 
-      - name: Create PR and enable auto-merge
+      # main is protected and requires the "Build & Test" check to pass. A PR
+      # opened with the default GITHUB_TOKEN won't auto-trigger that check
+      # (GitHub suppresses recursive triggers from the built-in token), so we
+      # kick it off explicitly, then let auto-merge complete once it passes.
+      - name: Open PR and wait for merge
         if: env.BRANCH != ''
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CITY: ${{ github.event.client_payload.chapter_city }}
         run: |
           gh pr create \
@@ -153,5 +156,40 @@ jobs:
             --body "Auto-generated chapter page.
 
           Triggered by \`chapter-approved\` repository dispatch."
-          gh pr merge "${BRANCH}" --auto --squash || echo "::warning::Auto-merge could not be enabled — please merge the PR manually once CI passes"
-          echo "✅ PR created — will merge to main once CI passes"
+          PR_NUMBER=$(gh pr view "${BRANCH}" --json number -q .number)
+
+          gh workflow run ci.yml --ref "${BRANCH}"
+          gh pr merge "$PR_NUMBER" --auto --squash
+
+          echo "Waiting for PR #$PR_NUMBER to merge..."
+          for i in $(seq 1 40); do
+            STATE=$(gh pr view "$PR_NUMBER" --json state -q .state)
+            if [ "$STATE" = "MERGED" ]; then
+              echo "✅ PR #$PR_NUMBER merged"
+              exit 0
+            fi
+            if [ "$STATE" = "CLOSED" ]; then
+              echo "::error::PR #$PR_NUMBER was closed without merging"
+              exit 1
+            fi
+            sleep 15
+          done
+          echo "::error::Timed out waiting for PR #$PR_NUMBER to merge (CI may have failed)"
+          exit 1
+
+      - name: Deploy to production
+        if: env.BRANCH != ''
+        run: |
+          git fetch origin main live-version-swa
+          git checkout live-version-swa
+          git merge origin/main --no-edit
+          git push origin live-version-swa
+          echo "✅ Chapter page merged to live-version-swa"
+
+      - name: Trigger SWA deploy
+        if: env.BRANCH != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run azure-static-web-apps-lively-desert-0f1f18c10.yml --ref live-version-swa
+          echo "✅ SWA deploy triggered"

--- a/.github/workflows/generate-event.yml
+++ b/.github/workflows/generate-event.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_PAT }}
 
       - name: Geocode event location
         run: |
@@ -127,10 +126,14 @@ jobs:
           git push origin "${BRANCH}"
           echo "BRANCH=${BRANCH}" >> "$GITHUB_ENV"
 
-      - name: Create PR and enable auto-merge
+      # main is protected and requires the "Build & Test" check to pass. A PR
+      # opened with the default GITHUB_TOKEN won't auto-trigger that check
+      # (GitHub suppresses recursive triggers from the built-in token), so we
+      # kick it off explicitly, then let auto-merge complete once it passes.
+      - name: Open PR and wait for merge
         if: env.BRANCH != ''
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT_TITLE: ${{ github.event.client_payload.event_title }}
         run: |
           gh pr create \
@@ -140,5 +143,40 @@ jobs:
             --body "Auto-generated event page.
 
           Triggered by \`event-created\` repository dispatch."
-          gh pr merge "${BRANCH}" --auto --squash || echo "::warning::Auto-merge could not be enabled — please merge the PR manually once CI passes"
-          echo "✅ PR created — will merge to main once CI passes"
+          PR_NUMBER=$(gh pr view "${BRANCH}" --json number -q .number)
+
+          gh workflow run ci.yml --ref "${BRANCH}"
+          gh pr merge "$PR_NUMBER" --auto --squash
+
+          echo "Waiting for PR #$PR_NUMBER to merge..."
+          for i in $(seq 1 40); do
+            STATE=$(gh pr view "$PR_NUMBER" --json state -q .state)
+            if [ "$STATE" = "MERGED" ]; then
+              echo "✅ PR #$PR_NUMBER merged"
+              exit 0
+            fi
+            if [ "$STATE" = "CLOSED" ]; then
+              echo "::error::PR #$PR_NUMBER was closed without merging"
+              exit 1
+            fi
+            sleep 15
+          done
+          echo "::error::Timed out waiting for PR #$PR_NUMBER to merge (CI may have failed)"
+          exit 1
+
+      - name: Deploy to production
+        if: env.BRANCH != ''
+        run: |
+          git fetch origin main live-version-swa
+          git checkout live-version-swa
+          git merge origin/main --no-edit
+          git push origin live-version-swa
+          echo "✅ Event page merged to live-version-swa"
+
+      - name: Trigger SWA deploy
+        if: env.BRANCH != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run azure-static-web-apps-lively-desert-0f1f18c10.yml --ref live-version-swa
+          echo "✅ SWA deploy triggered"


### PR DESCRIPTION
## Context

PR #144 fixed the branch-protection push failure conceptually (PR + auto-merge instead of direct push) but left it broken in practice:
- `token: ${{ secrets.GH_PAT }}` (checkout) and `GH_TOKEN: ${{ secrets.GH_PAT }}` (PR creation) both reference a secret that was **never created** — both steps would fail with auth errors.
- The "Deploy to production" and "Trigger SWA deploy" steps were removed entirely, so even a successful merge to `main` would not go live without a separate manual release — breaking the actual documented flow: change on `main` → push to `live-version-swa` → deploy.

## Fix

- Uses the default `GITHUB_TOKEN` everywhere instead of `GH_PAT` — **no new secret needed**.
- Adds an explicit `gh workflow run ci.yml --ref <branch>` call. GitHub suppresses auto-triggered checks for events created by the default token, so without this the required "Build & Test" check never runs against the bot's PR and auto-merge stalls forever.
- Polls for merge completion (~10 min timeout) before proceeding.
- Restores "Deploy to production" + "Trigger SWA deploy" steps after merge, now using `origin/main` (not stale local `main`) so the just-merged commit is actually picked up.
- Adds `workflow_dispatch` to `ci.yml` so it can be triggered explicitly.

## Testing

- All 4 modified workflow YAML files validated with `yaml.safe_load`.
- Repo settings `allow_auto_merge` and `delete_branch_on_merge` already enabled (needed for the auto-merge step).
- Plan to validate end-to-end immediately after merge by publishing the Sydney event through the real `event-created` flow.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>