### PR TITLE
Use default GITHUB_TOKEN for the CI workflow_dispatch call

### DIFF
--- a/.github/workflows/delete-chapter.yml
+++ b/.github/workflows/delete-chapter.yml
@@ -122,7 +122,9 @@ jobs:
           Triggered by \`delete-chapter\` workflow dispatch."
           PR_NUMBER=$(gh pr view "${BRANCH}" --json number -q .number)
 
-          gh workflow run ci.yml --ref "${BRANCH}"
+          # The PR-scoped PAT can't dispatch workflow runs, so use the
+          # default token (which has Actions access) just for this call.
+          GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" gh workflow run ci.yml --ref "${BRANCH}"
           gh pr merge "$PR_NUMBER" --auto --squash
 
           echo "Waiting for PR #$PR_NUMBER to merge..."

--- a/.github/workflows/generate-chapter.yml
+++ b/.github/workflows/generate-chapter.yml
@@ -161,7 +161,9 @@ jobs:
           Triggered by \`chapter-approved\` repository dispatch."
           PR_NUMBER=$(gh pr view "${BRANCH}" --json number -q .number)
 
-          gh workflow run ci.yml --ref "${BRANCH}"
+          # The PR-scoped PAT can't dispatch workflow runs, so use the
+          # default token (which has Actions access) just for this call.
+          GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" gh workflow run ci.yml --ref "${BRANCH}"
           gh pr merge "$PR_NUMBER" --auto --squash
 
           echo "Waiting for PR #$PR_NUMBER to merge..."

--- a/.github/workflows/generate-event.yml
+++ b/.github/workflows/generate-event.yml
@@ -148,7 +148,9 @@ jobs:
           Triggered by \`event-created\` repository dispatch."
           PR_NUMBER=$(gh pr view "${BRANCH}" --json number -q .number)
 
-          gh workflow run ci.yml --ref "${BRANCH}"
+          # The PR-scoped PAT can't dispatch workflow runs, so use the
+          # default token (which has Actions access) just for this call.
+          GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" gh workflow run ci.yml --ref "${BRANCH}"
           gh pr merge "$PR_NUMBER" --auto --squash
 
           echo "Waiting for PR #$PR_NUMBER to merge..."


### PR DESCRIPTION
## Follow-up to #147

Live test of the Sydney event dispatch confirmed `GH_PR_TOKEN` works exactly as intended — `gh pr create` succeeded where the default `GITHUB_TOKEN` was previously blocked by org policy (see PR #148, closed).

However, the next line, `gh workflow run ci.yml --ref "${BRANCH}"`, failed:

```
could not create workflow dispatch event: HTTP 403: Resource not accessible by personal access token
```

`GH_PR_TOKEN` is intentionally scoped to **Pull requests: read & write only** (no Actions access), so it can't dispatch workflow runs. Fix: only the `gh pr create` / `gh pr merge` calls need the PAT; the CI dispatch call now explicitly uses `${{ secrets.GITHUB_TOKEN }}`, which already has Actions write access in this repo.

## Testing

- YAML validated with `yaml.safe_load` on all 3 files.
- Plan to re-fire the Sydney event dispatch once this merges to confirm the full flow (PR create → CI trigger → CI pass → auto-merge → deploy) completes end-to-end.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>