### PR TITLE
Fill in correct content for Sydney event page

### DIFF
--- a/src/events/global-security-bootcamp-sydney-2026/index.md
+++ b/src/events/global-security-bootcamp-sydney-2026/index.md
@@ -3,10 +3,10 @@ layout: event.njk
 title: "Global Security Bootcamp Sydney 2026"
 slug: "global-security-bootcamp-sydney-2026"
 date: "2026-08-13"
-location: ""
+location: "Macquarie Cloud Services"
 description: |
-  
-sessionizeApiId: ""
-registrationCap: 0
+  Global Security Bootcamp Sydney 2026 — AI security, Architecture, Identity is the story of the year. Join Sydney's First Microsoft security community for a free, half-day event featuring real-world talks from practitioners who are building, defending, and securing Microsoft environments right now — no vendor pitches, no theory, just lessons from the field. This year's line-up reflects where the industry is heading: securing Identity, Azure workload, Copilot and AI agents before they become the next attack surface, deciding how much trust an AI system should be given with government and enterprise data, and revisiting the fundamentals — identity, landing zones, Azure and Architecture hygiene — that AI adoption is quietly putting under pressure. Add Sydney's own take on Microsoft AI, Architecture, identity & Sentinel, and you've got a day that connects the emerging with the essential.
+sessionizeApiId: "a8cyh82i"
+registrationCap: 80
 chapterSlug: "sydney"
 ---


### PR DESCRIPTION
Restores the real event content (location, description, sessionizeApiId, registrationCap) for the Sydney event page. It was published via `generate-event.yml` with a test dispatch payload that used slightly wrong field names, so the merged page had blank content in those fields. This PR fixes the content to match the original event submission.