### PR TITLE
Add community organiser registration reports

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -28,6 +28,7 @@ const fixEventChapterHandler = require('./functions/fixEventChapter');
 const deleteEventHandler = require('./functions/deleteEvent');
 const resendTicketEmailHandler = require('./functions/resendTicketEmail');
 const getAuditLogHandler = require('./functions/getAuditLog');
+const registrationReportHandler = require('./functions/registrationReport');
 
 /**
  * Wraps a POST handler with CSRF header verification.
@@ -76,3 +77,4 @@ app.post('fixEventChapter', { authLevel: 'anonymous', handler: withCsrf(fixEvent
 app.post('deleteEvent', { authLevel: 'anonymous', handler: withCsrf(deleteEventHandler) });
 app.post('resendTicketEmail', { authLevel: 'anonymous', handler: withCsrf(resendTicketEmailHandler) });
 app.get('getAuditLog', { authLevel: 'anonymous', handler: getAuditLogHandler });
+app.get('registrationReport', { authLevel: 'anonymous', handler: registrationReportHandler });

--- a/api/src/functions/registrationReport.js
+++ b/api/src/functions/registrationReport.js
@@ -1,0 +1,186 @@
+const { getAuthUser, hasRole, unauthorised, forbidden, isSuperAdmin, resolveEmail } = require('../helpers/auth');
+const { listEvents, getEventById, getRegistrationsByEvent, getDemographicsByEvent } = require('../helpers/tableStorage');
+
+function csvCell(value) {
+  const s = String(value || '');
+  const safe = /^[=+\-@\t\r]/.test(s) ? "'" + s : s;
+  return `"${safe.replace(/"/g, '""')}"`;
+}
+
+function boolLabel(value) {
+  return value === true || value === 'true' ? 'Yes' : 'No';
+}
+
+async function buildRows(events) {
+  const rows = [];
+
+  for (const event of events) {
+    const eventId = event.rowKey;
+    const [registrations, demographics] = await Promise.all([
+      getRegistrationsByEvent(eventId),
+      getDemographicsByEvent(eventId)
+    ]);
+    const demographicsByRegistration = new Map(demographics.map(d => [d.rowKey, d]));
+
+    registrations.forEach(registration => {
+      const demo = demographicsByRegistration.get(registration.rowKey) || {};
+      rows.push({
+        eventId,
+        eventTitle: event.title || '',
+        eventDate: event.date || '',
+        chapterSlug: event.chapterSlug || event.partitionKey || '',
+        registrationId: registration.rowKey,
+        fullName: registration.fullName || '',
+        email: registration.email || '',
+        company: registration.company || '',
+        role: registration.role || 'attendee',
+        volunteerInterest: registration.volunteerInterest === true || registration.volunteerInterest === 'true',
+        checkedIn: registration.checkedIn === true || registration.checkedIn === 'true',
+        checkedInAt: registration.checkedInAt || '',
+        registeredAt: registration.registeredAt || '',
+        employmentStatus: demo.employmentStatus || '',
+        industry: demo.industry || '',
+        jobTitle: demo.jobTitle || registration.jobTitle || '',
+        companySize: demo.companySize || '',
+        experienceLevel: demo.experienceLevel || ''
+      });
+    });
+  }
+
+  return rows.sort((a, b) => (b.registeredAt || '').localeCompare(a.registeredAt || ''));
+}
+
+async function buildEventSummaries(events) {
+  const summaries = [];
+
+  for (const event of events) {
+    const registrations = await getRegistrationsByEvent(event.rowKey);
+    summaries.push({
+      id: event.rowKey,
+      title: event.title || '',
+      date: event.date || '',
+      chapterSlug: event.chapterSlug || event.partitionKey || '',
+      registrationCount: registrations.length
+    });
+  }
+
+  return summaries.sort((a, b) => (b.date || '').localeCompare(a.date || ''));
+}
+
+/**
+ * GET /api/registrationReport?action=events
+ * GET /api/registrationReport?eventId={eventId}&format=csv
+ * Community-organiser-only report of event registration profile and demographics fields.
+ */
+module.exports = async function registrationReport(request, context) {
+  try {
+    const user = getAuthUser(request);
+    if (!user) return unauthorised();
+    if (!hasRole(user, 'admin')) return forbidden('Only community organisers can access reports');
+
+    const email = await resolveEmail(user);
+    if (!isSuperAdmin(email)) {
+      return forbidden('Only community organisers can access reports');
+    }
+
+    const url = new URL(request.url);
+    const eventId = url.searchParams.get('eventId');
+    let events;
+
+    if (eventId) {
+      const event = await getEventById(eventId);
+      if (!event) {
+        return {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ error: 'Event not found' })
+        };
+      }
+      events = [event];
+    } else {
+      events = await listEvents();
+    }
+
+    if (url.searchParams.get('action') === 'events') {
+      const summaries = await buildEventSummaries(events);
+      return {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          events: summaries,
+          totalEvents: summaries.length,
+          totalRegistrations: summaries.reduce((sum, event) => sum + event.registrationCount, 0)
+        })
+      };
+    }
+
+    const rows = await buildRows(events);
+
+    if (url.searchParams.get('format') === 'csv') {
+      const header = [
+        'Event Title',
+        'Event Date',
+        'Chapter',
+        'Name',
+        'Email',
+        'Company',
+        'Role',
+        'Volunteer Interest',
+        'Checked In',
+        'Checked In At',
+        'Registered At',
+        'Employment Status',
+        'Industry',
+        'Job Title',
+        'Company Size',
+        'Experience Level'
+      ];
+      const body = header.map(csvCell).join(',') + '\n' + rows.map(row => [
+        row.eventTitle,
+        row.eventDate,
+        row.chapterSlug,
+        row.fullName,
+        row.email,
+        row.company,
+        row.role,
+        boolLabel(row.volunteerInterest),
+        boolLabel(row.checkedIn),
+        row.checkedInAt,
+        row.registeredAt,
+        row.employmentStatus,
+        row.industry,
+        row.jobTitle,
+        row.companySize,
+        row.experienceLevel
+      ].map(csvCell).join(',')).join('\n');
+
+      return {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/csv',
+          'Content-Disposition': `attachment; filename="${eventId ? `registration-report-${eventId}` : 'registration-report-all-events'}.csv"`
+        },
+        body
+      };
+    }
+
+    return {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        totalRegistrations: rows.length,
+        totalEvents: new Set(rows.map(row => row.eventId)).size,
+        totalChapters: new Set(rows.map(row => row.chapterSlug).filter(Boolean)).size,
+        latestRegisteredAt: rows[0] ? rows[0].registeredAt : '',
+        rows
+      })
+    };
+  } catch (error) {
+    context.log(`registrationReport error: ${error.message}`);
+    return {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Internal server error' })
+    };
+  }
+};

--- a/api/src/functions/roles.js
+++ b/api/src/functions/roles.js
@@ -1,4 +1,4 @@
-const { getAuthUser, hasRole, unauthorised, forbidden } = require('../helpers/auth');
+const { isSuperAdmin } = require('../helpers/auth');
 const { getApprovedApplicationByEmail, isVolunteerForAnyEvent, isVolunteerOrOrganiserByRegistration, storeUserEmail } = require('../helpers/tableStorage');
 
 /**
@@ -54,9 +54,16 @@ module.exports = async function (request, context) {
 
     const roles = [];
 
+    // Community organisers are managed via SUPER_ADMIN_EMAILS and get admin access even without a chapter.
+    const superAdmin = isSuperAdmin(email);
+    if (superAdmin) {
+      roles.push('admin');
+      context.log(`Assigned admin role to ${email} (community organiser)`);
+    }
+
     // Check if this email belongs to an approved chapter lead
     const application = await getApprovedApplicationByEmail(email);
-    if (application) {
+    if (application && !roles.includes('admin')) {
       roles.push('admin');
       context.log(`Assigned admin role to ${email} (chapter lead for ${application.city})`);
     }

--- a/api/src/helpers/tableStorage.js
+++ b/api/src/helpers/tableStorage.js
@@ -295,6 +295,18 @@ async function storeDemographics(demographics) {
   return entity;
 }
 
+async function getDemographicsByEvent(eventId) {
+  const client = getTableClient('EventDemographics');
+  const entities = client.listEntities({
+    queryOptions: { filter: `PartitionKey eq '${eventId.replace(/'/g, "''")}'` }
+  });
+  const results = [];
+  for await (const entity of entities) {
+    results.push(entity);
+  }
+  return results;
+}
+
 // ─── Badges ───
 
 async function storeBadge(badge) {
@@ -649,7 +661,7 @@ module.exports = {
   storeRegistration, getRegistrationByTicketCode, getRegistrationsByUser,
   getRegistrationsByEvent, countRegistrations, updateRegistration,
   deleteRegistration, deleteDemographics,
-  storeDemographics,
+  storeDemographics, getDemographicsByEvent,
   storeBadge, getBadge, getBadgesByEvent,
   storeVolunteer, getVolunteersByEvent, removeVolunteer, isVolunteerForAnyEvent,
   getRegistrationsByRole, isVolunteerOrOrganiserByRegistration, VALID_ROLES,

--- a/api/tests/functions-coverage.test.js
+++ b/api/tests/functions-coverage.test.js
@@ -32,6 +32,7 @@ jest.mock('../src/helpers/tableStorage', () => ({
   updateRegistration: jest.fn().mockResolvedValue({}),
   deleteRegistration: jest.fn().mockResolvedValue({}),
   storeDemographics: jest.fn().mockResolvedValue({}),
+  getDemographicsByEvent: jest.fn().mockResolvedValue([]),
   deleteDemographics: jest.fn().mockResolvedValue({}),
   storeBadge: jest.fn().mockResolvedValue({}),
   getBadge: jest.fn(),
@@ -919,6 +920,94 @@ describe('eventAttendance function', () => {
     expect(res.headers['Content-Type']).toBe('text/csv');
     expect(res.body).toContain('Name,Email');
     expect(res.body).toContain('Alice');
+  });
+});
+
+// ─── registrationReport ──────────────────────────────────────────────
+
+describe('registrationReport function', () => {
+  const registrationReport = require('../src/functions/registrationReport');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPER_ADMIN_EMAILS = 'test@example.com';
+  });
+
+  afterEach(() => {
+    delete process.env.SUPER_ADMIN_EMAILS;
+  });
+
+  test('rejects non-community organisers', async () => {
+    process.env.SUPER_ADMIN_EMAILS = 'other@example.com';
+    const req = makeAuthRequest('GET', null, ['admin']);
+    req.url = 'https://example.com/api/registrationReport?action=events';
+
+    const res = await registrationReport(req, context);
+
+    expect(res.status).toBe(403);
+  });
+
+  test('returns event summaries for community organisers', async () => {
+    storage.listEvents.mockResolvedValueOnce([
+      { rowKey: 'ev-1', title: 'Perth Event', chapterSlug: 'perth', date: '2026-05-15' },
+      { rowKey: 'ev-2', title: 'Sydney Event', chapterSlug: 'sydney', date: '2026-06-20' }
+    ]);
+    storage.getRegistrationsByEvent
+      .mockResolvedValueOnce([{ rowKey: 'r1' }])
+      .mockResolvedValueOnce([{ rowKey: 'r2' }, { rowKey: 'r3' }]);
+
+    const req = makeAuthRequest('GET', null, ['admin']);
+    req.url = 'https://example.com/api/registrationReport?action=events';
+    const res = await registrationReport(req, context);
+
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.totalEvents).toBe(2);
+    expect(body.totalRegistrations).toBe(3);
+    expect(body.events[0].id).toBe('ev-2');
+  });
+
+  test('returns per-event CSV with demographics for community organisers', async () => {
+    storage.getEventById.mockResolvedValueOnce({
+      rowKey: 'ev-1',
+      title: 'Perth Event',
+      chapterSlug: 'perth',
+      date: '2026-05-15'
+    });
+    storage.getRegistrationsByEvent.mockResolvedValueOnce([
+      {
+        rowKey: 'r1',
+        fullName: 'Alice',
+        email: 'alice@example.com',
+        company: 'Example Co',
+        role: 'attendee',
+        volunteerInterest: true,
+        checkedIn: false,
+        registeredAt: '2026-05-01T00:00:00Z'
+      }
+    ]);
+    storage.getDemographicsByEvent.mockResolvedValueOnce([
+      {
+        rowKey: 'r1',
+        employmentStatus: 'Employed',
+        industry: 'Cybersecurity',
+        jobTitle: 'Analyst',
+        companySize: '51-200',
+        experienceLevel: 'Intermediate'
+      }
+    ]);
+
+    const req = makeAuthRequest('GET', null, ['admin']);
+    req.url = 'https://example.com/api/registrationReport?eventId=ev-1&format=csv';
+    const res = await registrationReport(req, context);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['Content-Type']).toBe('text/csv');
+    expect(res.headers['Content-Disposition']).toContain('registration-report-ev-1.csv');
+    expect(res.body).toContain('"Perth Event"');
+    expect(res.body).toContain('"Alice"');
+    expect(res.body).toContain('"Cybersecurity"');
+    expect(res.body).toContain('"Intermediate"');
   });
 });
 

--- a/api/tests/functions.test.js
+++ b/api/tests/functions.test.js
@@ -268,6 +268,7 @@ describe('roles function', () => {
   const roles = require('../src/functions/roles');
 
   beforeEach(() => jest.clearAllMocks());
+  afterEach(() => { delete process.env.SUPER_ADMIN_EMAILS; });
 
   test('returns empty roles for unknown email', async () => {
     storage.getApprovedApplicationByEmail.mockResolvedValueOnce(null);
@@ -280,6 +281,15 @@ describe('roles function', () => {
   test('returns admin role for approved chapter lead', async () => {
     storage.getApprovedApplicationByEmail.mockResolvedValueOnce({ city: 'Perth', email: 'lead@test.com' });
     const req = makeRequest('POST', { userId: 'u1', userDetails: 'lead@test.com' });
+    const res = await roles(req, context);
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body).roles).toContain('admin');
+  });
+
+  test('returns admin role for community organiser email', async () => {
+    process.env.SUPER_ADMIN_EMAILS = 'community@test.com';
+    storage.getApprovedApplicationByEmail.mockResolvedValueOnce(null);
+    const req = makeRequest('POST', { userId: 'u1', userDetails: 'community@test.com' });
     const res = await roles(req, context);
     expect(res.status).toBe(200);
     expect(JSON.parse(res.body).roles).toContain('admin');

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2933,6 +2933,74 @@ a.event-card:hover { color: inherit; }
 .dash-card-desc { font-size: var(--text-sm); color: var(--color-text-muted); margin: 0 0 var(--space-sm) 0; }
 .dash-card-info { font-size: var(--text-sm); color: var(--color-text-muted); margin: 0; }
 
+/* Dashboard — community reports */
+.reports-visuals {
+  margin-top: var(--space-xl);
+}
+
+.report-kpi-grid,
+.report-chart-grid {
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.report-kpi-grid {
+  grid-template-columns: repeat(4, 1fr);
+  margin-bottom: var(--space-lg);
+}
+
+.report-chart-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.report-kpi {
+  text-align: center;
+}
+
+.report-chart h3 {
+  margin: 0 0 var(--space-md) 0;
+  font-size: var(--text-lg);
+}
+
+.report-bars {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.report-bar-label {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-md);
+  margin-bottom: var(--space-xs);
+  font-size: var(--text-sm);
+}
+
+.report-bar-label span {
+  overflow-wrap: anywhere;
+}
+
+.report-bar-track {
+  height: 0.7rem;
+  overflow: hidden;
+  border-radius: var(--radius-pill);
+  background: var(--color-surface-code);
+}
+
+.report-bar-fill {
+  height: 100%;
+  min-width: 2px;
+  border-radius: var(--radius-pill);
+  background: linear-gradient(90deg, var(--color-primary-teal), var(--color-primary-navy-soft));
+}
+
+@media (max-width: 768px) {
+  .report-kpi-grid,
+  .report-chart-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Dashboard — sessionize speakers */
 .dash-speakers-list { margin-top: var(--space-md); }
 .dash-speakers-label { font-size: var(--text-xs); color: var(--color-text-muted); margin: 0 0 var(--space-xs) 0; }

--- a/src/dashboard/index.md
+++ b/src/dashboard/index.md
@@ -13,6 +13,7 @@ title: Dashboard
     <button id="btn-events">My Events</button>
     <button id="btn-create" class="btn-navy">Create Event</button>
     <button id="btn-chapter" class="btn-outline">Edit Chapter</button>
+    <button id="btn-reports" class="btn-outline is-hidden">Community Reports</button>
   </div>
 
   <!-- Events List -->
@@ -95,6 +96,29 @@ title: Dashboard
       <a id="create-progress-link" href="#" class="btn is-hidden inline-mt">View Event Page →</a>
       <button id="create-another-btn" type="button" class="is-hidden inline-mt-sm">Create Another Event</button>
     </div>
+  </div>
+
+  <!-- Community Reports (super admin only) -->
+  <div id="section-reports" class="is-hidden">
+    <div class="detail-actions">
+      <button id="btn-back-reports" class="btn-outline">&larr; Back to Events</button>
+    </div>
+    <h2>Community Reports</h2>
+    <p class="text-muted">Download registration profile and demographics data. This section is only available to community organisers.</p>
+    <div id="reports-summary" class="detail-panel"></div>
+    <div class="reg-form-wrap">
+      <div class="form-group">
+        <label for="report-event">Event</label>
+        <select id="report-event">
+          <option value="">All events</option>
+        </select>
+      </div>
+      <button id="report-download-btn" type="button">Download CSV</button>
+    </div>
+    <div id="reports-visuals" class="reports-visuals" aria-live="polite">
+      <p class="text-muted">Loading report data...</p>
+    </div>
+    <div id="reports-message" class="form-message is-hidden" role="alert"></div>
   </div>
 
   <!-- Event Detail (attendance) -->

--- a/src/js/dashboard.js
+++ b/src/js/dashboard.js
@@ -3,6 +3,7 @@
   var currentEventId = '';
   var currentChapterSlug = '';
   var eventsLoadedPromise = null;
+  var communityReportEvents = [];
 
   // Quill rich text editor configuration
   var quillToolbar = [
@@ -32,13 +33,13 @@
   function showSection(s) {
     currentSection = s;
     history.replaceState(null, '', '#' + s);
-    ['events','create','detail','edit-event','chapter'].forEach(function(id) {
+    ['events','create','detail','edit-event','chapter','reports'].forEach(function(id) {
       document.getElementById('section-' + id).style.display = id === s ? 'block' : 'none';
     });
   }
 
   // Restore section from URL hash
-  var validSections = ['events','create','detail','edit-event','chapter'];
+  var validSections = ['events','create','detail','edit-event','chapter','reports'];
   var initialHash = location.hash.replace('#', '');
   if (validSections.indexOf(initialHash) !== -1) {
     showSection(initialHash);
@@ -61,6 +62,10 @@
   });
   document.getElementById('btn-chapter').addEventListener('click', function() { showSection('chapter'); loadChapterEdit(); });
   document.getElementById('btn-back-events').addEventListener('click', function() { showSection('events'); });
+  document.getElementById('btn-reports').addEventListener('click', function() { showSection('reports'); loadCommunityReports(); });
+  document.getElementById('btn-back-reports').addEventListener('click', function() { showSection('events'); });
+  document.getElementById('report-download-btn').addEventListener('click', downloadCommunityReport);
+  document.getElementById('report-event').addEventListener('change', loadSelectedCommunityReport);
 
   // Check auth — assign to eventsLoadedPromise so loadChapterEdit() can wait for it
   eventsLoadedPromise = fetch('/.auth/me')
@@ -68,7 +73,9 @@
     .then(function(d) {
       if (d.clientPrincipal) {
         document.getElementById('dash-user').textContent = 'Welcome, ' + (d.clientPrincipal.userDetails || 'Admin');
-        return loadEvents();
+        return loadEvents().then(function() {
+          return initCommunityReports();
+        });
       }
     })
     .catch(function() {
@@ -123,6 +130,161 @@
       .catch(function(err) {
         document.getElementById('events-list').innerHTML = '<p>' + GSC.esc(err.message || 'Failed to load events.') + '</p>';
       });
+  }
+
+  function initCommunityReports() {
+    return GSC.fetch('/api/registrationReport?action=events')
+      .then(function(r) {
+        if (!r.ok) return null;
+        return r.json();
+      })
+      .then(function(data) {
+        if (!data) return;
+        communityReportEvents = data.events || [];
+        document.getElementById('btn-reports').classList.remove('is-hidden');
+      })
+      .catch(function() {
+        document.getElementById('btn-reports').classList.add('is-hidden');
+      });
+  }
+
+  function loadCommunityReports() {
+    var msg = document.getElementById('reports-message');
+    msg.style.display = 'none';
+    GSC.fetch('/api/registrationReport?action=events')
+      .then(function(r) {
+        if (!r.ok) {
+          throw new Error(r.status === 403 ? 'Only community organisers can access reports.' : 'Failed to load reports.');
+        }
+        return r.json();
+      })
+      .then(function(data) {
+        communityReportEvents = data.events || [];
+        document.getElementById('reports-summary').innerHTML =
+          '<div class="card stat-card"><p class="stat-number">' + (data.totalEvents || 0) + '</p><p class="stat-label">Events</p></div>' +
+          '<div class="card stat-card"><p class="stat-number">' + (data.totalRegistrations || 0) + '</p><p class="stat-label">Registrations</p></div>';
+
+        var select = document.getElementById('report-event');
+        var html = '<option value="">All events</option>';
+        communityReportEvents.forEach(function(ev) {
+          var label = (ev.date ? ev.date + ' - ' : '') + ev.title + ' (' + ev.registrationCount + ')';
+          html += '<option value="' + GSC.esc(ev.id) + '">' + GSC.esc(label) + '</option>';
+        });
+        select.innerHTML = html;
+        loadSelectedCommunityReport();
+      })
+      .catch(function(err) {
+        msg.style.display = 'block';
+        msg.style.backgroundColor = '#f8d7da';
+        msg.style.color = '#721c24';
+        msg.textContent = err.message || 'Failed to load reports.';
+      });
+  }
+
+  function loadSelectedCommunityReport() {
+    var eventId = document.getElementById('report-event').value;
+    var visuals = document.getElementById('reports-visuals');
+    var url = '/api/registrationReport';
+    if (eventId) url += '?eventId=' + encodeURIComponent(eventId);
+
+    visuals.innerHTML = '<p class="text-muted">Loading report data...</p>';
+    GSC.fetch(url)
+      .then(function(r) {
+        if (!r.ok) throw new Error('Failed to load report data.');
+        return r.json();
+      })
+      .then(renderReportVisuals)
+      .catch(function(err) {
+        visuals.innerHTML = '<p class="text-muted">' + GSC.esc(err.message || 'Failed to load report data.') + '</p>';
+      });
+  }
+
+  function downloadCommunityReport() {
+    var eventId = document.getElementById('report-event').value;
+    var url = '/api/registrationReport?format=csv';
+    if (eventId) url += '&eventId=' + encodeURIComponent(eventId);
+    window.open(url, '_blank');
+  }
+
+  function renderReportVisuals(data) {
+    var rows = data.rows || [];
+    var total = rows.length;
+    var checkedIn = rows.filter(function(r) { return r.checkedIn; }).length;
+    var volunteers = rows.filter(function(r) { return r.volunteerInterest; }).length;
+    var chapters = uniqueCount(rows, 'chapterSlug');
+    var html = '';
+
+    if (total === 0) {
+      document.getElementById('reports-visuals').innerHTML = '<p class="text-muted">No registrations found for this selection.</p>';
+      return;
+    }
+
+    html += '<div class="report-kpi-grid">';
+    html += reportKpi('Registrations', total);
+    html += reportKpi('Checked In', checkedIn + ' (' + percentage(checkedIn, total) + '%)');
+    html += reportKpi('Volunteer Interest', volunteers + ' (' + percentage(volunteers, total) + '%)');
+    html += reportKpi('Chapters', chapters);
+    html += '</div>';
+
+    html += '<div class="report-chart-grid">';
+    html += barChart('Registrations by chapter', countBy(rows, 'chapterSlug'), total);
+    html += barChart('Employment status', countBy(rows, 'employmentStatus'), total);
+    html += barChart('Industry', countBy(rows, 'industry'), total);
+    html += barChart('Experience level', countBy(rows, 'experienceLevel'), total);
+    html += barChart('Company size', countBy(rows, 'companySize'), total);
+    html += barChart('Role', countBy(rows, 'role'), total);
+    html += '</div>';
+
+    document.getElementById('reports-visuals').innerHTML = html;
+  }
+
+  function reportKpi(label, value) {
+    return '<div class="card report-kpi"><p class="stat-number">' + GSC.esc(String(value)) + '</p><p class="stat-label">' + GSC.esc(label) + '</p></div>';
+  }
+
+  function countBy(rows, field) {
+    var counts = {};
+    rows.forEach(function(row) {
+      var value = row[field] || 'Not provided';
+      counts[value] = (counts[value] || 0) + 1;
+    });
+    return Object.keys(counts).map(function(label) {
+      return { label: label, count: counts[label] };
+    }).sort(function(a, b) {
+      if (b.count !== a.count) return b.count - a.count;
+      return a.label.localeCompare(b.label);
+    }).slice(0, 8);
+  }
+
+  function barChart(title, items, total) {
+    var html = '<div class="card report-chart"><h3>' + GSC.esc(title) + '</h3>';
+    if (!items.length) {
+      html += '<p class="text-muted">No data.</p></div>';
+      return html;
+    }
+    html += '<div class="report-bars">';
+    items.forEach(function(item) {
+      var pct = percentage(item.count, total);
+      html += '<div class="report-bar-row">';
+      html += '<div class="report-bar-label"><span>' + GSC.esc(item.label) + '</span><strong>' + item.count + '</strong></div>';
+      html += '<div class="report-bar-track"><div class="report-bar-fill" style="width:' + pct + '%"></div></div>';
+      html += '</div>';
+    });
+    html += '</div></div>';
+    return html;
+  }
+
+  function percentage(value, total) {
+    if (!total) return 0;
+    return Math.round((value / total) * 100);
+  }
+
+  function uniqueCount(rows, field) {
+    var seen = {};
+    rows.forEach(function(row) {
+      if (row[field]) seen[row[field]] = true;
+    });
+    return Object.keys(seen).length;
   }
 
   function viewEvent(eventId, chapterSlug, eventTitle, sessionizeApiId) {

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -164,6 +164,11 @@
       "headers": { "Cache-Control": "private, no-store" }
     },
     {
+      "route": "/api/registrationReport",
+      "allowedRoles": ["admin"],
+      "headers": { "Cache-Control": "private, no-store" }
+    },
+    {
       "route": "/api/*",
       "allowedRoles": ["anonymous"],
       "headers": { "Cache-Control": "no-cache, no-store, must-revalidate" }


### PR DESCRIPTION
## Summary
- Add a community-organiser-only registration report API gated by `SUPER_ADMIN_EMAILS`
- Support event list, per-event CSV export, all-events CSV export, and JSON report data
- Add dashboard Community Reports visualisations and CSV download
- Grant `admin` role to `SUPER_ADMIN_EMAILS` users so they can reach the dashboard route

## Validation
- `node -c src/js/dashboard.js`
- `node -c api/src/functions/registrationReport.js`
- `node -c api/src/functions/roles.js`
- `node -c api/src/app.js`
- `cd api && npm test -- --runInBand`
- `npm run build`