### PR TITLE
Prevent duplicate chapter applications and notify admins

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -214,7 +214,8 @@ The chapters listing page (`/chapters/`) features an interactive map powered by 
 - All email functions in `api/src/helpers/emailService.js`
 - Sender: `DoNotReply@globalsecurity.community`
 - ACS resource: `gsc-core-acs`, Email service: `gsc-core-ces`
-- Send emails as non-blocking fire-and-forget (don't fail the parent operation if email fails)
+- Await email delivery attempts, but catch failures so they do not fail the persisted parent operation
+- New chapter applications and contact requests email each address in `SUPER_ADMIN_EMAILS` privately after persistence
 - Ticket confirmation email includes: event details, QR code, "View Event" button (links to event page), "My Tickets" button, and Discord invite section with chapter name
 - All emails use `emailLayout()` wrapper for consistent GSC branding (dark header, teal accent gradient)
 
@@ -311,6 +312,7 @@ API secrets are stored in `api/local.settings.json` (gitignored). Required value
 | `CIAM_CLIENT_ID` | Azure AD B2C app client ID |
 | `CIAM_CLIENT_SECRET` | Azure AD B2C app client secret |
 | `AZURE_COMMUNICATION_CONNECTION_STRING` | ACS connection (optional — emails fail gracefully) |
+| `SUPER_ADMIN_EMAILS` | Comma-separated community organiser addresses used for admin access and submission notifications |
 | `DISCORD_BOT_TOKEN` | Discord bot token (optional — notifications fail gracefully) |
 | `DISCORD_CONTACT_CHANNEL_ID` | Discord channel ID for contact form submissions |
 | `DISCORD_NOTIFICATIONS_CHANNEL_ID` | Discord channel ID for chapter/event notifications |

--- a/api/src/functions/chapterApplication.js
+++ b/api/src/functions/chapterApplication.js
@@ -1,10 +1,12 @@
 const { randomUUID } = require('crypto');
-const { storeApplication } = require('../helpers/tableStorage');
+const { storeApplication, getApprovedApplicationBySlug } = require('../helpers/tableStorage');
 const { generateApprovalToken } = require('../helpers/tokenHelper');
 const { sendMessage } = require('../helpers/discordBot');
+const { sendChapterApplicationAdminEmail } = require('../helpers/emailService');
 const { sanitiseFields } = require('../helpers/sanitise');
 const { checkRateLimit, getClientIP } = require('../helpers/rateLimiter');
 const { verifyTurnstileToken } = require('../helpers/turnstile');
+const { cityToSlug } = require('../helpers/auth');
 
 const MAX_REQUESTS_PER_WINDOW = parseInt(process.env.MAX_CHAPTER_REQUESTS_PER_WINDOW || '3');
 
@@ -125,12 +127,25 @@ module.exports = async function (request, context) {
       }
     }
 
-    const applicationId = randomUUID();
     const sanitised = sanitiseFields(
       { fullName, email, city, country, linkedIn, github, whyLead, existingCommunity,
         secondLeadName, secondLeadEmail, secondLeadLinkedIn, secondLeadGitHub },
       ['fullName', 'city', 'country', 'whyLead', 'existingCommunity', 'secondLeadName', 'email', 'secondLeadEmail']
     );
+    const chapterSlug = cityToSlug(sanitised.city.trim());
+    const existingChapter = await getApprovedApplicationBySlug(chapterSlug);
+    if (existingChapter) {
+      return {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          existingChapter: true,
+          redirectUrl: `/chapters/${chapterSlug}/?application=existing`
+        })
+      };
+    }
+
+    const applicationId = randomUUID();
     const application = {
       id: applicationId,
       fullName: sanitised.fullName.trim(),
@@ -149,6 +164,12 @@ module.exports = async function (request, context) {
 
     // Store in Azure Table Storage
     await storeApplication(application);
+
+    try {
+      await sendChapterApplicationAdminEmail(application, context);
+    } catch (emailError) {
+      context.log(`Chapter application admin email failed: ${emailError.message}`);
+    }
 
     // Send Discord notification via bot
     const discordChannelId = process.env.DISCORD_NOTIFICATIONS_CHANNEL_ID;

--- a/api/src/functions/contactForm.js
+++ b/api/src/functions/contactForm.js
@@ -1,5 +1,5 @@
-const { app } = require('@azure/functions');
 const { sendMessage } = require('../helpers/discordBot');
+const { sendContactSubmissionAdminEmail } = require('../helpers/emailService');
 const { stripHtml } = require('../helpers/sanitise');
 const { storeContactSubmission } = require('../helpers/tableStorage');
 const { verifyTurnstileToken } = require('../helpers/turnstile');
@@ -122,12 +122,16 @@ module.exports = async function (request, context) {
       };
     }
 
-    // Store in Table Storage (primary persistence)
+    const submission = { name: safeName, email, subject: safeSubject, message: safeMessage };
+
+    // Store before notifying so a successful response always means the submission is persisted.
+    await storeContactSubmission(submission);
+    context.log('Contact form stored in Table Storage');
+
     try {
-      await storeContactSubmission({ name: safeName, email, subject: safeSubject, message: safeMessage });
-      context.log('Contact form stored in Table Storage');
-    } catch (storeErr) {
-      context.log(`Table Storage error (non-blocking): ${storeErr.message}`);
+      await sendContactSubmissionAdminEmail(submission, context);
+    } catch (emailError) {
+      context.log(`Contact submission admin email failed: ${emailError.message}`);
     }
 
     // Get Discord channel ID from environment

--- a/api/src/helpers/emailService.js
+++ b/api/src/helpers/emailService.js
@@ -304,4 +304,93 @@ async function sendEventNotificationEmail(subscriberEmail, event, context) {
   }
 }
 
-module.exports = { sendTicketEmail, sendBadgeEmail, sendCancellationEmail, sendEventNotificationEmail };
+function getSuperAdminEmails() {
+  return [...new Set(
+    (process.env.SUPER_ADMIN_EMAILS || '')
+      .split(',')
+      .map(email => email.trim().toLowerCase())
+      .filter(Boolean)
+  )];
+}
+
+async function sendSuperAdminEmail(subject, bodyHtml, context) {
+  const recipients = getSuperAdminEmails();
+  if (recipients.length === 0) {
+    if (context) context.log('SUPER_ADMIN_EMAILS is not configured — skipping admin email notification');
+    return [];
+  }
+
+  let client;
+  try {
+    client = getEmailClient();
+  } catch (err) {
+    if (context) context.log(`Admin email notification skipped: ${err.message}`);
+    return [];
+  }
+
+  const results = await Promise.allSettled(recipients.map(async recipient => {
+    const poller = await client.beginSend({
+      senderAddress: SENDER_ADDRESS,
+      content: {
+        subject,
+        html: emailLayout(bodyHtml)
+      },
+      recipients: {
+        to: [{ address: recipient }]
+      }
+    });
+    return poller.pollUntilDone();
+  }));
+
+  results.forEach((result, index) => {
+    if (!context) return;
+    if (result.status === 'fulfilled') {
+      context.log(`Admin email notification sent to ${recipients[index]}`);
+    } else {
+      context.log(`Admin email notification FAILED | to: ${recipients[index]} | error: ${result.reason.message}`);
+    }
+  });
+  return results;
+}
+
+async function sendChapterApplicationAdminEmail(application, context) {
+  const safeLocation = `${application.city}, ${application.country}`.replace(/[\r\n]+/g, ' ').trim();
+  const secondLead = application.secondLeadName
+    ? `<tr><td style="padding:6px 10px;font-weight:600;">Second lead</td><td style="padding:6px 10px;">${escapeHtml(application.secondLeadName)}${application.secondLeadEmail ? ` (${escapeHtml(application.secondLeadEmail)})` : ''}</td></tr>`
+    : '';
+  const bodyHtml = `
+    <h2 style="color:#001f3f;margin:0 0 16px 0;">New Chapter Application</h2>
+    <table style="width:100%;border-collapse:collapse;background:#f8f9fa;">
+      <tr><td style="padding:6px 10px;font-weight:600;">Location</td><td style="padding:6px 10px;">${escapeHtml(application.city)}, ${escapeHtml(application.country)}</td></tr>
+      <tr><td style="padding:6px 10px;font-weight:600;">Applicant</td><td style="padding:6px 10px;">${escapeHtml(application.fullName)} (${escapeHtml(application.email)})</td></tr>
+      ${secondLead}
+    </table>
+    <h3 style="color:#001f3f;margin:20px 0 8px 0;">Why they want to lead</h3>
+    <p style="color:#555;white-space:pre-wrap;">${escapeHtml(application.whyLead)}</p>
+    ${application.existingCommunity ? `<h3 style="color:#001f3f;margin:20px 0 8px 0;">Existing community</h3><p style="color:#555;white-space:pre-wrap;">${escapeHtml(application.existingCommunity)}</p>` : ''}
+    <p style="color:#777;font-size:0.9em;margin-top:24px;">Review and action this application from the configured Discord notifications channel.</p>`;
+  return sendSuperAdminEmail(`New chapter application: ${safeLocation}`, bodyHtml, context);
+}
+
+async function sendContactSubmissionAdminEmail(submission, context) {
+  const safeSubject = (submission.subject || '').replace(/[\r\n]+/g, ' ').trim();
+  const bodyHtml = `
+    <h2 style="color:#001f3f;margin:0 0 16px 0;">New Contact Request</h2>
+    <table style="width:100%;border-collapse:collapse;background:#f8f9fa;">
+      <tr><td style="padding:6px 10px;font-weight:600;">Name</td><td style="padding:6px 10px;">${escapeHtml(submission.name)}</td></tr>
+      <tr><td style="padding:6px 10px;font-weight:600;">Email</td><td style="padding:6px 10px;">${escapeHtml(submission.email)}</td></tr>
+      <tr><td style="padding:6px 10px;font-weight:600;">Subject</td><td style="padding:6px 10px;">${escapeHtml(submission.subject)}</td></tr>
+    </table>
+    <h3 style="color:#001f3f;margin:20px 0 8px 0;">Message</h3>
+    <p style="color:#555;white-space:pre-wrap;">${escapeHtml(submission.message)}</p>`;
+  return sendSuperAdminEmail(`New contact request: ${safeSubject}`, bodyHtml, context);
+}
+
+module.exports = {
+  sendTicketEmail,
+  sendBadgeEmail,
+  sendCancellationEmail,
+  sendEventNotificationEmail,
+  sendChapterApplicationAdminEmail,
+  sendContactSubmissionAdminEmail
+};

--- a/api/tests/emailService.test.js
+++ b/api/tests/emailService.test.js
@@ -1,0 +1,81 @@
+const mockBeginSend = jest.fn();
+const mockPollUntilDone = jest.fn().mockResolvedValue({ status: 'Succeeded' });
+
+jest.mock('@azure/communication-email', () => ({
+  EmailClient: jest.fn().mockImplementation(() => ({ beginSend: mockBeginSend }))
+}));
+
+describe('superadmin email notifications', () => {
+  let emailService;
+  const context = { log: jest.fn() };
+
+  beforeAll(() => {
+    process.env.AZURE_COMMUNICATION_CONNECTION_STRING = 'endpoint=https://test/;accesskey=test';
+    emailService = require('../src/helpers/emailService');
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPER_ADMIN_EMAILS = ' First@Example.com,second@example.com,first@example.com ';
+    mockBeginSend.mockResolvedValue({ pollUntilDone: mockPollUntilDone });
+    mockPollUntilDone.mockResolvedValue({ status: 'Succeeded' });
+  });
+
+  afterAll(() => {
+    delete process.env.AZURE_COMMUNICATION_CONNECTION_STRING;
+    delete process.env.SUPER_ADMIN_EMAILS;
+  });
+
+  test('emails each unique superadmin privately and escapes chapter application content', async () => {
+    await emailService.sendChapterApplicationAdminEmail({
+      fullName: '<script>alert(1)</script>',
+      email: 'applicant@example.com',
+      city: 'Perth',
+      country: 'Australia',
+      whyLead: '<b>Build a community</b>',
+      existingCommunity: '',
+      secondLeadName: '',
+      secondLeadEmail: ''
+    }, context);
+
+    expect(mockBeginSend).toHaveBeenCalledTimes(2);
+    expect(mockBeginSend.mock.calls.map(call => call[0].recipients.to[0].address)).toEqual([
+      'first@example.com',
+      'second@example.com'
+    ]);
+    mockBeginSend.mock.calls.forEach(call => {
+      expect(call[0].recipients.to).toHaveLength(1);
+      expect(call[0].content.html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+      expect(call[0].content.html).toContain('&lt;b&gt;Build a community&lt;/b&gt;');
+      expect(call[0].content.html).not.toContain('<script>');
+    });
+  });
+
+  test('escapes contact message content and strips newlines from the email subject', async () => {
+    await emailService.sendContactSubmissionAdminEmail({
+      name: 'Alice',
+      email: 'alice@example.com',
+      subject: 'Hello\r\nBCC: victim@example.com',
+      message: '<img src=x onerror=alert(1)>'
+    }, context);
+
+    const message = mockBeginSend.mock.calls[0][0];
+    expect(message.content.subject).toBe('New contact request: Hello BCC: victim@example.com');
+    expect(message.content.html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+    expect(message.content.html).not.toContain('<img src=x');
+  });
+
+  test('does nothing when no superadmin recipients are configured', async () => {
+    delete process.env.SUPER_ADMIN_EMAILS;
+
+    const results = await emailService.sendContactSubmissionAdminEmail({
+      name: 'Alice',
+      email: 'alice@example.com',
+      subject: 'Hello',
+      message: 'Test'
+    }, context);
+
+    expect(results).toEqual([]);
+    expect(mockBeginSend).not.toHaveBeenCalled();
+  });
+});

--- a/api/tests/functions-coverage.test.js
+++ b/api/tests/functions-coverage.test.js
@@ -43,7 +43,7 @@ jest.mock('../src/helpers/tableStorage', () => ({
   VALID_ROLES: ['attendee', 'volunteer', 'speaker', 'sponsor', 'organiser'],
   getApprovedApplicationByEmail: jest.fn(),
   getApprovedApplicationsByEmail: jest.fn().mockResolvedValue([{ city: 'Perth' }]),
-  getApprovedApplicationBySlug: jest.fn(),
+  getApprovedApplicationBySlug: jest.fn().mockResolvedValue(null),
   storeSessionizeCache: jest.fn().mockResolvedValue({}),
   getSessionizeCache: jest.fn(),
   storeSubscription: jest.fn().mockResolvedValue({}),
@@ -66,7 +66,9 @@ jest.mock('../src/helpers/emailService', () => ({
   sendTicketEmail: jest.fn().mockResolvedValue({}),
   sendBadgeEmail: jest.fn().mockResolvedValue({}),
   sendCancellationEmail: jest.fn().mockResolvedValue({}),
-  sendEventNotificationEmail: jest.fn().mockResolvedValue({})
+  sendEventNotificationEmail: jest.fn().mockResolvedValue({}),
+  sendChapterApplicationAdminEmail: jest.fn().mockResolvedValue([]),
+  sendContactSubmissionAdminEmail: jest.fn().mockResolvedValue([])
 }));
 
 jest.mock('../src/helpers/rateLimiter', () => ({
@@ -237,6 +239,21 @@ describe('contactForm function', () => {
     expect(res.status).toBe(200);
     expect(JSON.parse(res.body).success).toBe(true);
     expect(storage.storeContactSubmission).toHaveBeenCalled();
+    expect(emailService.sendContactSubmissionAdminEmail).toHaveBeenCalledWith({
+      name: 'Alice',
+      email: 'alice@test.com',
+      subject: 'Test',
+      message: 'Hello world'
+    }, context);
+  });
+
+  test('returns 500 when contact submission cannot be persisted', async () => {
+    storage.storeContactSubmission.mockRejectedValueOnce(new Error('storage unavailable'));
+    const res = await contactForm(contactRequest({
+      name: 'Alice', email: 'alice@test.com', subject: 'Test', message: 'Hello world'
+    }), context);
+    expect(res.status).toBe(500);
+    expect(emailService.sendContactSubmissionAdminEmail).not.toHaveBeenCalled();
   });
 
   test('rate limits after too many requests from same IP', async () => {
@@ -339,7 +356,29 @@ describe('chapterApplication function', () => {
     expect(res.status).toBe(200);
     expect(JSON.parse(res.body).success).toBe(true);
     expect(storage.storeApplication).toHaveBeenCalledTimes(1);
+    expect(emailService.sendChapterApplicationAdminEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ city: 'Perth', country: 'Australia', email: 'alice@test.com' }),
+      context
+    );
     expect(discord.sendMessage).toHaveBeenCalledWith('test-notif-channel', expect.any(Object), context);
+  });
+
+  test('redirects to an approved chapter without storing or notifying', async () => {
+    storage.getApprovedApplicationBySlug.mockResolvedValueOnce({ city: 'New York' });
+    const res = await chapterApplication(makeRequest('POST', {
+      ...validBody, city: ' New York!! '
+    }), context);
+    const body = JSON.parse(res.body);
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      existingChapter: true,
+      redirectUrl: '/chapters/new-york/?application=existing'
+    });
+    expect(storage.getApprovedApplicationBySlug).toHaveBeenCalledWith('new-york');
+    expect(storage.storeApplication).not.toHaveBeenCalled();
+    expect(emailService.sendChapterApplicationAdminEmail).not.toHaveBeenCalled();
+    expect(discord.sendMessage).not.toHaveBeenCalled();
   });
 });
 

--- a/src/_includes/layouts/chapter.njk
+++ b/src/_includes/layouts/chapter.njk
@@ -12,6 +12,8 @@ layout: base.njk
     <p class="chapter-subtitle">{{ city }}, {{ country }}</p>
   </header>
 
+  <div id="existing-chapter-notice" class="form-message is-hidden" role="status"></div>
+
   <section class="page-section">
     <h2>About This Chapter</h2>
     <p>Welcome to the Global Security Community chapter in {{ city }}! We bring together security professionals and enthusiasts in the {{ city }} area to share knowledge, network, and grow together.</p>
@@ -96,3 +98,4 @@ layout: base.njk
 
 <script src="/js/scroll-reveal.js?v={{ cacheBust }}"></script>
 <script src="/js/chapter-partners.js?v={{ cacheBust }}"></script>
+<script src="/js/chapter-existing-notice.js?v={{ cacheBust }}"></script>

--- a/src/js/chapter-apply-form.js
+++ b/src/js/chapter-apply-form.js
@@ -55,7 +55,13 @@ document.getElementById('chapter-apply-form').addEventListener('submit', async f
 
     var data = await response.json();
 
-    if (response.ok) {
+    if (response.ok && data.existingChapter) {
+      if (/^\/chapters\/[a-z0-9-]+\/\?application=existing$/.test(data.redirectUrl || '')) {
+        window.location.assign(data.redirectUrl);
+        return;
+      }
+      GSC.showMessage(formMessage, 'error', 'This chapter already exists, but its page could not be opened. Please use the chapter directory.');
+    } else if (response.ok) {
       GSC.showMessage(formMessage, 'success', data.message || 'Application submitted successfully!');
       document.getElementById('chapter-apply-form').reset();
       if (typeof turnstile !== 'undefined') turnstile.reset();

--- a/src/js/chapter-existing-notice.js
+++ b/src/js/chapter-existing-notice.js
@@ -1,0 +1,14 @@
+(function() {
+  var params = new URLSearchParams(window.location.search);
+  if (params.get('application') !== 'existing') return;
+
+  var notice = document.getElementById('existing-chapter-notice');
+  if (!notice) return;
+
+  GSC.showMessage(notice, 'warning', 'This chapter already exists. Please reach out to one of the chapter leads below if you would like to get involved.');
+  notice.classList.remove('is-hidden');
+
+  params.delete('application');
+  var query = params.toString();
+  window.history.replaceState({}, '', window.location.pathname + (query ? '?' + query : '') + window.location.hash);
+})();


### PR DESCRIPTION
## Summary
- redirect duplicate chapter applicants to the existing chapter with an accessible notice
- email persisted chapter and contact submissions privately to configured superadmins
- preserve Discord notifications and add regression coverage

## Validation
- npm test (API)
- npx @11ty/eleventy