### PR TITLE
Release chapter hero CSP fix

### DIFF
--- a/src/chapters/index.md
+++ b/src/chapters/index.md
@@ -7,7 +7,7 @@ badgeThemeYear: 2026
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.min.css">
 
-<header class="chapters-hero" style="--chapters-hero-image: url('/assets/badge-themes/2026-hero.webp?v={{ cacheBust }}')">
+<header class="chapters-hero">
   <div class="container chapters-hero__content">
     <h1>Global Chapters</h1>
     <p>Our chapters are the foundation of the Global Security Community. Find your local chapter on the map or browse the list below.</p>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -973,7 +973,7 @@ a.card-link h3 {
   position: absolute;
   z-index: 0;
   inset: 0;
-  background: var(--chapters-hero-image) center 24% / cover no-repeat;
+  background: url("/assets/badge-themes/2026-hero.webp") center 24% / cover no-repeat;
   content: "";
   transform: scale(1.02);
 }


### PR DESCRIPTION
## Summary
- load the annual Chapters hero artwork from the approved stylesheet
- preserve the strict production Content Security Policy
- retain the corrected hero layering and heading contrast