### PR TITLE
Align Chapters hero with site layout

### DIFF
--- a/src/chapters/index.md
+++ b/src/chapters/index.md
@@ -7,12 +7,14 @@ badgeThemeYear: 2026
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.min.css">
 
-<header class="chapters-hero">
-  <div class="container chapters-hero__content">
-    <h1>Global Chapters</h1>
-    <p>Our chapters are the foundation of the Global Security Community. Find your local chapter on the map or browse the list below.</p>
-  </div>
-</header>
+<div class="container">
+  <header class="chapters-hero">
+    <div class="chapters-hero__content">
+      <h1>Global Chapters</h1>
+      <p>Our chapters are the foundation of the Global Security Community. Find your local chapter on the map or browse the list below.</p>
+    </div>
+  </header>
+</div>
 
 <div class="container">
   {% if collections.chapter and collections.chapter.length > 0 %}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -963,10 +963,12 @@ a.card-link h3 {
   display: flex;
   min-height: 360px;
   align-items: flex-end;
-  margin: calc(-1 * var(--space-3xl)) -20px var(--space-2xl);
+  margin: 0 auto var(--space-2xl);
   overflow: hidden;
   isolation: isolate;
+  border-radius: var(--radius-lg);
   background: var(--color-primary-navy-deep);
+  box-shadow: var(--shadow-lg);
 }
 
 .chapters-hero::before {
@@ -989,8 +991,7 @@ a.card-link h3 {
 .chapters-hero__content {
   position: relative;
   z-index: 2;
-  padding-top: clamp(3rem, 8vw, 5.5rem);
-  padding-bottom: var(--space-2xl);
+  padding: clamp(3rem, 8vw, 5.5rem) clamp(2.5rem, 6vw, 5rem) var(--space-2xl);
   color: var(--color-text-inverse);
 }
 


### PR DESCRIPTION
## Summary
- contain the Chapters hero within the same content rail as Home and About
- use the shared large corner radius and shadow treatment
- align hero copy padding with the Home page while retaining the annual artwork

## Validation
- Eleventy production build
- desktop and mobile visual review
- `git diff --check`