### PR TITLE
Add local artwork heroes to chapter pages

### DIFF
--- a/api/src/functions/chapterArtwork.js
+++ b/api/src/functions/chapterArtwork.js
@@ -1,10 +1,14 @@
-const { getChapterCardArtwork, ACTIVE_BADGE_THEME_YEAR } = require('../helpers/imageGenerator');
+const {
+  getChapterBadgeTheme,
+  getChapterCardArtwork,
+  ACTIVE_BADGE_THEME_YEAR
+} = require('../helpers/imageGenerator');
 
 const FALLBACK_URL = '/assets/GSC-Shield-Transparent.png';
 
 /**
- * GET /api/chapterArtwork?slug={chapterSlug}&year={year}
- * Public, cached chapter-card artwork generated from the annual theme.
+ * GET /api/chapterArtwork?slug={chapterSlug}&year={year}&variant={card|hero}
+ * Public, cached chapter artwork generated from the annual theme.
  */
 module.exports = async function chapterArtwork(request, context) {
   try {
@@ -12,19 +16,22 @@ module.exports = async function chapterArtwork(request, context) {
     const slug = (url.searchParams.get('slug') || '').trim().toLowerCase();
     const requestedYear = Number.parseInt(url.searchParams.get('year'), 10);
     const year = Number.isInteger(requestedYear) ? requestedYear : ACTIVE_BADGE_THEME_YEAR;
+    const variant = url.searchParams.get('variant') === 'hero' ? 'hero' : 'card';
 
     if (!/^[a-z0-9][a-z0-9-]{0,60}[a-z0-9]$/.test(slug) ||
         year < 2020 || year > 2100) {
       return redirectToFallback();
     }
 
-    const artwork = await getChapterCardArtwork(year, slug);
+    const artwork = variant === 'hero'
+      ? await getChapterBadgeTheme(year, slug)
+      : await getChapterCardArtwork(year, slug);
     if (!artwork) return redirectToFallback();
 
     return {
       status: 200,
       headers: {
-        'Content-Type': 'image/webp',
+        'Content-Type': variant === 'hero' ? 'image/png' : 'image/webp',
         'Cache-Control': 'public, max-age=86400, stale-while-revalidate=604800',
         'Content-Length': String(artwork.length)
       },

--- a/api/tests/functions-coverage.test.js
+++ b/api/tests/functions-coverage.test.js
@@ -104,6 +104,7 @@ jest.mock('../src/helpers/imageGenerator', () => ({
   callImageApi: jest.fn().mockResolvedValue(Buffer.from('mock')),
   uploadToBlob: jest.fn().mockResolvedValue('https://mock.blob.url/test.png'),
   downloadGeneratedImage: jest.fn().mockResolvedValue(Buffer.from('generated-image')),
+  getChapterBadgeTheme: jest.fn().mockResolvedValue(Buffer.from('chapter-theme')),
   getChapterCardArtwork: jest.fn().mockResolvedValue(Buffer.from('chapter-card')),
   ACTIVE_BADGE_THEME_YEAR: 2026
 }));
@@ -167,6 +168,17 @@ describe('chapterArtwork function', () => {
     expect(response.headers['Content-Type']).toBe('image/webp');
     expect(response.body).toEqual(Buffer.from('chapter-card'));
     expect(imageGenerator.getChapterCardArtwork).toHaveBeenCalledWith(2026, 'perth');
+  });
+
+  test('returns the full chapter artwork for a hero', async () => {
+    const response = await chapterArtwork({
+      url: 'https://globalsecurity.community/api/chapterArtwork?slug=perth&year=2026&variant=hero'
+    }, context);
+
+    expect(response.status).toBe(200);
+    expect(response.headers['Content-Type']).toBe('image/png');
+    expect(response.body).toEqual(Buffer.from('chapter-theme'));
+    expect(imageGenerator.getChapterBadgeTheme).toHaveBeenCalledWith(2026, 'perth');
   });
 
   test('redirects invalid or missing artwork to the standard shield', async () => {

--- a/src/_includes/layouts/chapter.njk
+++ b/src/_includes/layouts/chapter.njk
@@ -3,13 +3,18 @@ layout: base.njk
 ---
 
 <div class="container">
-  <div id="chapter-banner" data-chapter-slug="{{ city | lower | replace(" ", "-") }}" class="chapter-banner is-hidden">
-    <img id="chapter-banner-img" alt="{{ city }} Chapter Banner" class="chapter-banner-img">
-  </div>
-  <header class="chapter-page-header">
-    <p class="page-kicker">Local chapter</p>
-    <h1>Global Security Community {{ city }}</h1>
-    <p class="chapter-subtitle">{{ city }}, {{ country }}</p>
+  <header class="chapter-visual-hero">
+    <img
+      src="/api/chapterArtwork?slug={{ city | lower | replace(" ", "-") }}&year=2026&variant=hero"
+      alt="{{ city }} chapter artwork featuring local landmarks"
+      class="chapter-visual-hero__artwork"
+      width="1536"
+      height="1024"
+      fetchpriority="high">
+    <div class="chapter-visual-hero__content">
+      <h1>Global Security Community {{ city }}</h1>
+      <p>{{ city }}, {{ country }}</p>
+    </div>
   </header>
 
   <div id="existing-chapter-notice" class="form-message is-hidden" role="status"></div>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -728,6 +728,60 @@ body {
   margin-bottom: var(--space-3xl);
 }
 
+.chapter-visual-hero {
+  position: relative;
+  display: flex;
+  min-height: 360px;
+  align-items: flex-end;
+  margin-bottom: var(--space-3xl);
+  overflow: hidden;
+  isolation: isolate;
+  border-radius: var(--radius-lg);
+  background: var(--color-primary-navy-deep);
+  box-shadow: var(--shadow-lg);
+}
+
+.chapter-visual-hero::after {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(0, 31, 63, 0.08), rgba(6, 23, 44, 0.94));
+  content: "";
+}
+
+.chapter-visual-hero__artwork {
+  position: absolute;
+  z-index: 0;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center 42%;
+}
+
+.chapter-visual-hero__content {
+  position: relative;
+  z-index: 2;
+  padding: clamp(3rem, 8vw, 5.5rem) clamp(2.5rem, 6vw, 5rem) var(--space-2xl);
+  color: var(--color-text-inverse);
+}
+
+.chapter-visual-hero__content h1 {
+  max-width: 18ch;
+  margin: 0 0 var(--space-sm);
+  color: var(--color-text-inverse);
+  font-size: clamp(2.35rem, 6vw, 4.5rem);
+  line-height: 0.98;
+  letter-spacing: -0.035em;
+  text-wrap: balance;
+}
+
+.chapter-visual-hero__content p {
+  margin: 0;
+  color: var(--color-text-inverse-muted);
+  font-size: var(--text-lg);
+}
+
 .page-header h1,
 .chapter-page-header h1,
 .event-page-header h1 {
@@ -1618,7 +1672,8 @@ button:not(.nav-toggle):hover,
 }
 
 @media (max-width: 768px) {
-  .chapters-hero {
+  .chapters-hero,
+  .chapter-visual-hero {
     min-height: 300px;
   }
 
@@ -3017,18 +3072,6 @@ a.event-card:hover { color: inherit; }
 .inline-ml-sm { margin-left: var(--space-sm); }
 .card-padding-standard { padding: var(--space-2xl); }
 .skeleton-ticket { max-width: 420px; margin: 0 auto; }
-.chapter-banner {
-  margin-bottom: var(--space-xl);
-  border-radius: var(--radius-lg);
-  overflow: hidden;
-  max-height: 200px;
-}
-.chapter-banner-img {
-  width: 100%;
-  height: 200px;
-  object-fit: cover;
-  display: block;
-}
 .subscribe-message {
   margin: 0 0 var(--space-md) 0;
 }

--- a/src/js/chapter-events.js
+++ b/src/js/chapter-events.js
@@ -4,16 +4,6 @@
   var chapterSlug = container.getAttribute('data-chapter-slug');
   if (!chapterSlug) return;
 
-  // Try to load AI-generated chapter banner
-  var banner = document.getElementById('chapter-banner');
-  if (banner) {
-    var bannerUrl = 'https://gsccoresa.blob.core.windows.net/generated-images/chapters/' + encodeURIComponent(chapterSlug) + '-banner.png';
-    var img = document.getElementById('chapter-banner-img');
-    img.onload = function() { banner.style.display = 'block'; };
-    img.onerror = function() { banner.style.display = 'none'; };
-    img.src = bannerUrl;
-  }
-
   (async function() {
     try {
       var res = await fetch('/api/getEvent?action=list&chapter=' + encodeURIComponent(chapterSlug));


### PR DESCRIPTION
## Summary
- add a contained visual hero to the shared chapter layout
- use each chapter's existing full-resolution annual artwork and overlay its chapter name/location
- extend the cached artwork endpoint with a full-resolution hero variant
- remove the obsolete direct Blob Storage banner loader
- automatically cover all existing and future chapter pages through the shared layout

## Validation
- 137 focused API tests
- Eleventy production build
- desktop and mobile visual review
- `git diff --check`