### PR TITLE
Optimize chapter artwork heroes

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,10 @@
 const crypto = require('crypto');
 
+function chapterSlugFromUrl(value) {
+  const match = String(value || '').match(/^\/chapters\/([a-z0-9](?:[a-z0-9-]{0,60}[a-z0-9])?)\/$/);
+  return match ? match[1] : '';
+}
+
 module.exports = function(eleventyConfig) {
   // Copy static assets
   eleventyConfig.addPassthroughCopy("src/assets");
@@ -15,6 +20,9 @@ module.exports = function(eleventyConfig) {
     if (!value) return '';
     return crypto.createHash('md5').update(value.trim().toLowerCase()).digest('hex');
   });
+
+  // Chapter URLs are generated from the canonical application slug.
+  eleventyConfig.addFilter("chapterSlugFromUrl", chapterSlugFromUrl);
 
   // Date filters for date-based event grouping in templates
   eleventyConfig.addFilter("dateToMs", function(value) {
@@ -106,3 +114,5 @@ module.exports = function(eleventyConfig) {
     htmlTemplateEngine: "njk"
   };
 };
+
+module.exports.chapterSlugFromUrl = chapterSlugFromUrl;

--- a/api/src/functions/chapterArtwork.js
+++ b/api/src/functions/chapterArtwork.js
@@ -1,13 +1,13 @@
 const {
-  getChapterBadgeTheme,
   getChapterCardArtwork,
+  getChapterHeroArtwork,
   ACTIVE_BADGE_THEME_YEAR
 } = require('../helpers/imageGenerator');
 
 const FALLBACK_URL = '/assets/GSC-Shield-Transparent.png';
 
 /**
- * GET /api/chapterArtwork?slug={chapterSlug}&year={year}&variant={card|hero}
+ * GET /api/chapterArtwork?slug={chapterSlug}&year={year}&variant={card|hero-webp}
  * Public, cached chapter artwork generated from the annual theme.
  */
 module.exports = async function chapterArtwork(request, context) {
@@ -16,7 +16,10 @@ module.exports = async function chapterArtwork(request, context) {
     const slug = (url.searchParams.get('slug') || '').trim().toLowerCase();
     const requestedYear = Number.parseInt(url.searchParams.get('year'), 10);
     const year = Number.isInteger(requestedYear) ? requestedYear : ACTIVE_BADGE_THEME_YEAR;
-    const variant = url.searchParams.get('variant') === 'hero' ? 'hero' : 'card';
+    const requestedVariant = url.searchParams.get('variant');
+    const variant = requestedVariant === 'hero' || requestedVariant === 'hero-webp'
+      ? 'hero'
+      : 'card';
 
     if (!/^[a-z0-9][a-z0-9-]{0,60}[a-z0-9]$/.test(slug) ||
         year < 2020 || year > 2100) {
@@ -24,14 +27,14 @@ module.exports = async function chapterArtwork(request, context) {
     }
 
     const artwork = variant === 'hero'
-      ? await getChapterBadgeTheme(year, slug)
+      ? await getChapterHeroArtwork(year, slug, context)
       : await getChapterCardArtwork(year, slug);
     if (!artwork) return redirectToFallback();
 
     return {
       status: 200,
       headers: {
-        'Content-Type': variant === 'hero' ? 'image/png' : 'image/webp',
+        'Content-Type': 'image/webp',
         'Cache-Control': 'public, max-age=86400, stale-while-revalidate=604800',
         'Content-Length': String(artwork.length)
       },

--- a/api/src/helpers/imageGenerator.js
+++ b/api/src/helpers/imageGenerator.js
@@ -124,6 +124,31 @@ async function getChapterCardArtwork(year, chapterSlug) {
   return await downloadBlobPath(`badge-themes/${year}/chapters/${safeChapterSlug}-card.webp`);
 }
 
+async function createChapterHeroArtwork(year, chapterSlug, source, context) {
+  const safeChapterSlug = safeStorageSegment(chapterSlug, 'chapter');
+  const heroBuffer = await sharp(source)
+    .resize(1024, 576, { fit: 'cover', position: 'north' })
+    .webp({ quality: 82, effort: 5 })
+    .toBuffer();
+  await uploadToBlob(
+    heroBuffer,
+    `badge-themes/${year}/chapters/${safeChapterSlug}-hero.webp`,
+    context,
+    'image/webp'
+  );
+  return heroBuffer;
+}
+
+async function getChapterHeroArtwork(year, chapterSlug, context) {
+  const safeChapterSlug = safeStorageSegment(chapterSlug, 'chapter');
+  const cached = await downloadBlobPath(`badge-themes/${year}/chapters/${safeChapterSlug}-hero.webp`);
+  if (cached) return cached;
+
+  const source = await getChapterBadgeTheme(year, safeChapterSlug);
+  if (!source) return null;
+  return await createChapterHeroArtwork(year, safeChapterSlug, source, context);
+}
+
 async function generateAnnualBadgeTheme(year, context) {
   const prompt = `A square digital illustration forming the ${year} annual visual theme for Global Security Community event badges worldwide. ` +
     `Create one iconic, polished cybersecurity community scene that can be reused consistently across many different events and countries. ` +
@@ -157,12 +182,15 @@ async function generateChapterBadgeTheme(year, chapterSlug, city, country, annua
     .resize(720, 405, { fit: 'cover', position: 'north' })
     .webp({ quality: 78, effort: 5 })
     .toBuffer();
-  await uploadToBlob(
-    cardBuffer,
-    `badge-themes/${year}/chapters/${safeChapterSlug}-card.webp`,
-    context,
-    'image/webp'
-  );
+  await Promise.all([
+    uploadToBlob(
+      cardBuffer,
+      `badge-themes/${year}/chapters/${safeChapterSlug}-card.webp`,
+      context,
+      'image/webp'
+    ),
+    createChapterHeroArtwork(year, safeChapterSlug, buffer, context)
+  ]);
   return buffer;
 }
 
@@ -344,6 +372,7 @@ module.exports = {
   getAnnualBadgeTheme,
   getChapterBadgeTheme,
   getChapterCardArtwork,
+  getChapterHeroArtwork,
   generateAnnualBadgeTheme,
   generateChapterBadgeTheme,
   ensureChapterBadgeTheme,

--- a/api/tests/functions-coverage.test.js
+++ b/api/tests/functions-coverage.test.js
@@ -104,8 +104,8 @@ jest.mock('../src/helpers/imageGenerator', () => ({
   callImageApi: jest.fn().mockResolvedValue(Buffer.from('mock')),
   uploadToBlob: jest.fn().mockResolvedValue('https://mock.blob.url/test.png'),
   downloadGeneratedImage: jest.fn().mockResolvedValue(Buffer.from('generated-image')),
-  getChapterBadgeTheme: jest.fn().mockResolvedValue(Buffer.from('chapter-theme')),
   getChapterCardArtwork: jest.fn().mockResolvedValue(Buffer.from('chapter-card')),
+  getChapterHeroArtwork: jest.fn().mockResolvedValue(Buffer.from('chapter-hero')),
   ACTIVE_BADGE_THEME_YEAR: 2026
 }));
 
@@ -157,6 +157,7 @@ describe('chapterArtwork function', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     imageGenerator.getChapterCardArtwork.mockResolvedValue(Buffer.from('chapter-card'));
+    imageGenerator.getChapterHeroArtwork.mockResolvedValue(Buffer.from('chapter-hero'));
   });
 
   test('returns cached WebP artwork for a valid chapter', async () => {
@@ -170,15 +171,15 @@ describe('chapterArtwork function', () => {
     expect(imageGenerator.getChapterCardArtwork).toHaveBeenCalledWith(2026, 'perth');
   });
 
-  test('returns the full chapter artwork for a hero', async () => {
+  test('returns optimized WebP artwork for a hero', async () => {
     const response = await chapterArtwork({
-      url: 'https://globalsecurity.community/api/chapterArtwork?slug=perth&year=2026&variant=hero'
+      url: 'https://globalsecurity.community/api/chapterArtwork?slug=perth&year=2026&variant=hero-webp'
     }, context);
 
     expect(response.status).toBe(200);
-    expect(response.headers['Content-Type']).toBe('image/png');
-    expect(response.body).toEqual(Buffer.from('chapter-theme'));
-    expect(imageGenerator.getChapterBadgeTheme).toHaveBeenCalledWith(2026, 'perth');
+    expect(response.headers['Content-Type']).toBe('image/webp');
+    expect(response.body).toEqual(Buffer.from('chapter-hero'));
+    expect(imageGenerator.getChapterHeroArtwork).toHaveBeenCalledWith(2026, 'perth', context);
   });
 
   test('redirects invalid or missing artwork to the standard shield', async () => {

--- a/api/tests/imageGenerator.test.js
+++ b/api/tests/imageGenerator.test.js
@@ -41,7 +41,11 @@ jest.mock('../src/helpers/badgeGenerator', () => ({
 
 process.env.AZURE_STORAGE_CONNECTION_STRING = 'UseDevelopmentStorage=true';
 
-const { generateEventBadgeBackground } = require('../src/helpers/imageGenerator');
+const sharp = require('sharp');
+const {
+  generateEventBadgeBackground,
+  getChapterHeroArtwork
+} = require('../src/helpers/imageGenerator');
 
 describe('annual community badge themes', () => {
   beforeEach(() => {
@@ -83,9 +87,25 @@ describe('annual community badge themes', () => {
     expect(mockBlobs.get('badge-themes/2027/chapters/sydney.png')).toEqual(mockPng);
     expect(mockBlobs.has('badge-themes/2027/chapters/perth-card.webp')).toBe(true);
     expect(mockBlobs.has('badge-themes/2027/chapters/sydney-card.webp')).toBe(true);
+    expect(mockBlobs.has('badge-themes/2027/chapters/perth-hero.webp')).toBe(true);
+    expect(mockBlobs.has('badge-themes/2027/chapters/sydney-hero.webp')).toBe(true);
     expect(mockBlobs.has('events/perth-security-day-attendee.png')).toBe(true);
     expect(mockBlobs.has('events/perth-security-night-attendee.png')).toBe(true);
     expect(mockBlobs.has('events/sydney-security-day-speaker.png')).toBe(true);
     expect(mockBlobs.has('events/sydney-security-day-organiser.png')).toBe(true);
+  });
+
+  test('backfills an optimized hero from existing chapter artwork', async () => {
+    mockBlobs.set('badge-themes/2026/chapters/perth.png', mockPng);
+
+    const hero = await getChapterHeroArtwork(2026, 'perth');
+    const metadata = await sharp(hero).metadata();
+
+    expect(metadata).toMatchObject({ format: 'webp', width: 1024, height: 576 });
+    expect(hero.length).toBeLessThan(mockPng.length);
+    expect(mockBlobs.get('badge-themes/2026/chapters/perth-hero.webp')).toEqual(hero);
+
+    await getChapterHeroArtwork(2026, 'perth');
+    expect(mockBlobs.get('badge-themes/2026/chapters/perth-hero.webp')).toEqual(hero);
   });
 });

--- a/src/_includes/layouts/chapter.njk
+++ b/src/_includes/layouts/chapter.njk
@@ -2,15 +2,17 @@
 layout: base.njk
 ---
 
+{% set chapterSlug = page.url | chapterSlugFromUrl %}
 <div class="container">
   <header class="chapter-visual-hero">
     <img
-      src="/api/chapterArtwork?slug={{ city | lower | replace(" ", "-") }}&year=2026&variant=hero"
+      src="/api/chapterArtwork?slug={{ chapterSlug }}&year=2026&variant=hero-webp"
       alt="{{ city }} chapter artwork featuring local landmarks"
       class="chapter-visual-hero__artwork"
-      width="1536"
-      height="1024"
-      fetchpriority="high">
+      width="1024"
+      height="576"
+      fetchpriority="high"
+      decoding="async">
     <div class="chapter-visual-hero__content">
       <h1>Global Security Community {{ city }}</h1>
       <p>{{ city }}, {{ country }}</p>
@@ -60,7 +62,7 @@ layout: base.njk
 
   <section class="page-section reveal-on-scroll">
     <h2>Events</h2>
-    <div id="chapter-events" data-chapter-slug="{{ city | lower | replace(" ", "-") }}">
+    <div id="chapter-events" data-chapter-slug="{{ chapterSlug }}">
       <div class="skeleton-grid">
         <div class="skeleton skeleton-card"></div>
         <div class="skeleton skeleton-card"></div>
@@ -73,7 +75,7 @@ layout: base.njk
 
   <section class="page-section reveal-on-scroll">
     <h2>Get Involved</h2>
-    <div class="card" id="subscribe-card" data-chapter-slug="{{ city | lower | replace(" ", "-") }}">
+    <div class="card" id="subscribe-card" data-chapter-slug="{{ chapterSlug }}">
       <h3><span class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.2 8.4c.5.38.8.97.8 1.6v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V10a2 2 0 0 1 .8-1.6l8-6a2 2 0 0 1 2.4 0l8 6Z"/><path d="m22 10-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 10"/></svg></span> Chapter Event Notifications</h3>
       <p id="subscribe-msg" class="subscribe-message">Get an email when new events are announced for this chapter.</p>
       <button id="btn-subscribe" class="is-hidden">Subscribe</button>


### PR DESCRIPTION
## Summary
- derive chapter identifiers from the canonical chapter URL
- use the canonical slug consistently for artwork, events, and subscriptions
- serve cached 1024×576 WebP hero derivatives instead of full-resolution PNGs
- lazily backfill optimized heroes for existing chapter artwork
- generate optimized hero assets alongside future chapter artwork

## Validation
- 139 focused API tests
- Eleventy production build
- generated chapter markup inspection
- `git diff --check`