### PR TITLE
Protect development and production release flows

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -244,17 +244,14 @@ The chapters listing page (`/chapters/`) features an interactive map powered by 
 ## Branching Strategy
 
 - **`main`** — Development branch. All day-to-day work, feature branches, and generation workflows target `main`.
-- **`live-version-swa`** — Production branch. Deployed to Azure SWA. Only updated by merging `main` into it when a release is ready.
+- **`live-version-swa`** — Protected production branch. Deployed to Azure SWA. Only updated by a pull request from `main`.
 - **Feature branches** — For larger features, create a branch off `main`, work on it, then PR back to `main`.
 - **Releasing to production:**
   ```bash
-  git checkout live-version-swa
-  git merge main
-  git push origin live-version-swa
-  git checkout main
+  gh workflow run release-production.yml
   ```
-- **Generation workflows** (`generate-event.yml`, `generate-chapter.yml`, `delete-chapter.yml`) push to `main` only. They do NOT push to `live-version-swa`. Changes reach production on the next release merge.
-- **Never push directly to `live-version-swa`** — always merge from `main`.
+- **Generation workflows** (`generate-event.yml`, `generate-chapter.yml`, `delete-chapter.yml`) create squash-auto-merge PRs into `main`. They do not release to production automatically.
+- **Never push directly to `main` or `live-version-swa`** — both branches require pull requests and passing checks.
 
 ---
 
@@ -263,7 +260,7 @@ The chapters listing page (`/chapters/`) features an interactive map powered by 
 - **Frontend:** Eleventy builds to `_site/`, deployed by Azure SWA GitHub Action
 - **API:** Azure Functions in `api/` deployed alongside SWA
 - **SWA deploy triggers** on push to `live-version-swa` or PRs targeting it
-- **Generation workflows** push to `main` only — changes reach production on next release merge
+- **Generation workflows** use protected squash-auto-merge PRs into `main`; production release is explicit
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, live-version-swa]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/delete-chapter.yml
+++ b/.github/workflows/delete-chapter.yml
@@ -142,20 +142,3 @@ jobs:
           done
           echo "::error::Timed out waiting for PR #$PR_NUMBER to merge (CI may have failed)"
           exit 1
-
-      - name: Deploy to production
-        if: env.BRANCH != ''
-        run: |
-          git fetch origin main live-version-swa
-          git checkout live-version-swa
-          git merge origin/main --no-edit
-          git push origin live-version-swa
-          echo "✅ Chapter deletion merged to live-version-swa"
-
-      - name: Trigger SWA deploy
-        if: env.BRANCH != ''
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh workflow run azure-static-web-apps-lively-desert-0f1f18c10.yml --ref live-version-swa
-          echo "✅ SWA deploy triggered"

--- a/.github/workflows/generate-chapter.yml
+++ b/.github/workflows/generate-chapter.yml
@@ -181,20 +181,3 @@ jobs:
           done
           echo "::error::Timed out waiting for PR #$PR_NUMBER to merge (CI may have failed)"
           exit 1
-
-      - name: Deploy to production
-        if: env.BRANCH != ''
-        run: |
-          git fetch origin main live-version-swa
-          git checkout live-version-swa
-          git merge origin/main --no-edit
-          git push origin live-version-swa
-          echo "✅ Chapter page merged to live-version-swa"
-
-      - name: Trigger SWA deploy
-        if: env.BRANCH != ''
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh workflow run azure-static-web-apps-lively-desert-0f1f18c10.yml --ref live-version-swa
-          echo "✅ SWA deploy triggered"

--- a/.github/workflows/generate-event.yml
+++ b/.github/workflows/generate-event.yml
@@ -168,20 +168,3 @@ jobs:
           done
           echo "::error::Timed out waiting for PR #$PR_NUMBER to merge (CI may have failed)"
           exit 1
-
-      - name: Deploy to production
-        if: env.BRANCH != ''
-        run: |
-          git fetch origin main live-version-swa
-          git checkout live-version-swa
-          git merge origin/main --no-edit
-          git push origin live-version-swa
-          echo "✅ Event page merged to live-version-swa"
-
-      - name: Trigger SWA deploy
-        if: env.BRANCH != ''
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh workflow run azure-static-web-apps-lively-desert-0f1f18c10.yml --ref live-version-swa
-          echo "✅ SWA deploy triggered"

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -1,0 +1,52 @@
+name: Release to Production
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-production
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Open Production Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create or reuse release pull request
+        env:
+          GH_TOKEN: ${{ secrets.GH_PR_TOKEN }}
+        run: |
+          AHEAD=$(GH_TOKEN="${{ github.token }}" gh api \
+            "repos/${GITHUB_REPOSITORY}/compare/live-version-swa...main" \
+            --jq .ahead_by)
+          if [ "$AHEAD" -eq 0 ]; then
+            echo "Production already contains all commits from main"
+            exit 0
+          fi
+
+          PR_NUMBER=$(gh pr list \
+            --base live-version-swa \
+            --head main \
+            --state open \
+            --json number \
+            --jq '.[0].number')
+
+          if [ -z "$PR_NUMBER" ]; then
+            gh pr create \
+              --base live-version-swa \
+              --head main \
+              --title "Release main to production" \
+              --body "Promotes the tested state of \`main\` to \`live-version-swa\`."
+            PR_NUMBER=$(gh pr list \
+              --base live-version-swa \
+              --head main \
+              --state open \
+              --json number \
+              --jq '.[0].number')
+          fi
+
+          gh pr merge "$PR_NUMBER" --auto --merge
+          echo "Release PR #$PR_NUMBER will merge after all required checks pass"

--- a/.github/workflows/validate-release-source.yml
+++ b/.github/workflows/validate-release-source.yml
@@ -1,0 +1,25 @@
+name: Validate Production Release
+
+on:
+  pull_request:
+    branches: [live-version-swa]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  validate-source:
+    name: Validate Release Source
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require main as the source branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          TARGET_REPO: ${{ github.repository }}
+        run: |
+          if [ "$HEAD_REF" != "main" ] || [ "$HEAD_REPO" != "$TARGET_REPO" ]; then
+            echo "::error::Production releases must originate from ${TARGET_REPO}:main"
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,14 +32,16 @@ See [`.github/copilot-instructions.md`](.github/copilot-instructions.md) for det
 
 ## Deployment
 
-Merge `main` into `live-version-swa` to deploy:
+Run the production release workflow when the tested changes on `main` are ready:
 
 ```bash
-git checkout live-version-swa
-git merge main
-git push origin live-version-swa
-git checkout main
+gh workflow run release-production.yml
 ```
+
+The workflow opens a pull request from `main` into `live-version-swa` and enables merge-commit
+auto-merge. GitHub releases it after the required source, CI, CodeQL, and deployment-preview
+checks pass. Generated event and chapter pages use squash auto-merge into `main` but remain
+unreleased until this workflow is run.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -48,5 +48,5 @@ cd api && npm test
 
 ## Branching
 
-- `main` — development branch
-- `live-version-swa` — production (merge from main to release)
+- `main` — protected development branch
+- `live-version-swa` — protected production branch (release by PR from `main`)


### PR DESCRIPTION
## Summary
- run CI for pull requests targeting either protected branch
- keep generated content on `main` through existing squash auto-merge PRs, without automatic production promotion
- add an explicit release workflow that opens `main` → `live-version-swa` and enables merge-commit auto-merge
- reject production pull requests that do not originate from this repository's `main` branch
- remove direct production pushes from generation workflows
- document the protected staging and release model

## Intended protection model
- `main`: pull request required, zero approvals, CI and CodeQL required
- `live-version-swa`: pull request required, zero approvals, source validation, CI, CodeQL, and deployment preview required
- generated pages: squash auto-merge into `main` after checks
- production: explicit `Release to Production` workflow, then merge-commit auto-merge after checks