### PR TITLE
Fix production release workflow context

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - name: Create or reuse release pull request
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GH_PR_TOKEN }}
         run: |
           AHEAD=$(GH_TOKEN="${{ github.token }}" gh api \


### PR DESCRIPTION
The manual release workflow runs without a checkout, so GitHub CLI could not infer the repository for pull-request commands. Set `GH_REPO` explicitly so the protected `main` → `live-version-swa` release flow can create, reuse, and auto-merge its PR.