### PR TITLE
Add Discord approval for chapter releases

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -251,6 +251,7 @@ The chapters listing page (`/chapters/`) features an interactive map powered by 
   gh workflow run release-production.yml
   ```
 - **Generation workflows** (`generate-event.yml`, `generate-chapter.yml`, `delete-chapter.yml`) create squash-auto-merge PRs into `main`. They do not release to production automatically.
+- After a generated chapter merges into `main`, `generate-chapter.yml` posts a Discord release request bound to the exact `main` SHA. `/api/releaseApproval` requires the `admin` role and dispatches `release-approved`; the release workflow rejects the request if `main` has changed.
 - **Never push directly to `main` or `live-version-swa`** — both branches require pull requests and passing checks.
 
 ---

--- a/.github/workflows/generate-chapter.yml
+++ b/.github/workflows/generate-chapter.yml
@@ -181,3 +181,46 @@ jobs:
           done
           echo "::error::Timed out waiting for PR #$PR_NUMBER to merge (CI may have failed)"
           exit 1
+
+      - name: Request production release approval
+        if: env.BRANCH != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          CHANNEL_ID: ${{ github.event.client_payload.notification_channel_id }}
+          CITY: ${{ github.event.client_payload.chapter_city }}
+          SLUG: ${{ github.event.client_payload.chapter_slug }}
+        run: |
+          if [ -z "$BOT_TOKEN" ] || ! [[ "$CHANNEL_ID" =~ ^[0-9]+$ ]]; then
+            echo "::error::Discord release approval configuration is missing"
+            exit 1
+          fi
+
+          MAIN_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq .sha)
+          APPROVAL_PATH="/api/releaseApproval?sha=${MAIN_SHA}&chapter=${SLUG}"
+          APPROVAL_REDIRECT=$(jq -rn --arg value "$APPROVAL_PATH" '$value | @uri')
+          APPROVAL_URL="https://globalsecurity.community/.auth/login/ciam?post_login_redirect_uri=${APPROVAL_REDIRECT}"
+          REVIEW_URL="https://github.com/${GITHUB_REPOSITORY}/compare/live-version-swa...${MAIN_SHA}"
+          PAYLOAD=$(jq -n \
+            --arg city "$CITY" \
+            --arg sha "$MAIN_SHA" \
+            --arg approvalUrl "$APPROVAL_URL" \
+            --arg reviewUrl "$REVIEW_URL" \
+            '{
+              embeds: [{
+                title: "Chapter ready for production approval",
+                description: ("The generated **" + $city + "** chapter has passed checks and merged into `main`."),
+                color: 2142890,
+                fields: [
+                  { name: "Approved main commit", value: ("`" + $sha + "`"), inline: false },
+                  { name: "Actions", value: ("[Review all release changes](" + $reviewUrl + ") | [Approve production release](" + $approvalUrl + ")"), inline: false }
+                ],
+                footer: { text: "Approval is valid only while main remains at this commit." }
+              }]
+            }')
+
+          curl --fail-with-body --silent --show-error \
+            -X POST "https://discord.com/api/v10/channels/${CHANNEL_ID}/messages" \
+            -H "Authorization: Bot ${BOT_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data "$PAYLOAD"

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -2,6 +2,13 @@ name: Release to Production
 
 on:
   workflow_dispatch:
+    inputs:
+      expected_sha:
+        description: Optional exact main SHA to release
+        required: false
+        type: string
+  repository_dispatch:
+    types: [release-approved]
 
 permissions:
   contents: read
@@ -19,7 +26,24 @@ jobs:
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GH_PR_TOKEN }}
+          EXPECTED_SHA: ${{ github.event.client_payload.expected_sha || inputs.expected_sha || '' }}
+          APPROVED_BY: ${{ github.event.client_payload.approved_by || github.actor }}
         run: |
+          MAIN_SHA=$(GH_TOKEN="${{ github.token }}" gh api \
+            "repos/${GITHUB_REPOSITORY}/commits/main" \
+            --jq .sha)
+          if [ -n "$EXPECTED_SHA" ]; then
+            if ! [[ "$EXPECTED_SHA" =~ ^[a-f0-9]{40}$ ]]; then
+              echo "::error::Approved SHA is invalid"
+              exit 1
+            fi
+            if [ "$MAIN_SHA" != "$EXPECTED_SHA" ]; then
+              echo "::error::Main changed after approval. Expected $EXPECTED_SHA but found $MAIN_SHA"
+              exit 1
+            fi
+          fi
+          APPROVED_SHA="${EXPECTED_SHA:-$MAIN_SHA}"
+
           AHEAD=$(GH_TOKEN="${{ github.token }}" gh api \
             "repos/${GITHUB_REPOSITORY}/compare/live-version-swa...main" \
             --jq .ahead_by)
@@ -40,13 +64,27 @@ jobs:
               --base live-version-swa \
               --head main \
               --title "Release main to production" \
-              --body "Promotes the tested state of \`main\` to \`live-version-swa\`."
+              --body "Promotes the tested state of \`main\` to \`live-version-swa\`.
+
+          Approved by: ${APPROVED_BY}
+
+          <!-- approved-main-sha:${APPROVED_SHA} -->"
             PR_NUMBER=$(gh pr list \
               --base live-version-swa \
               --head main \
               --state open \
               --json number \
               --jq '.[0].number')
+          else
+            gh api \
+              --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+              -f body="Promotes the tested state of \`main\` to \`live-version-swa\`.
+
+          Approved by: ${APPROVED_BY}
+
+          <!-- approved-main-sha:${APPROVED_SHA} -->" \
+              >/dev/null
           fi
 
           gh pr merge "$PR_NUMBER" --auto --merge

--- a/.github/workflows/validate-release-source.yml
+++ b/.github/workflows/validate-release-source.yml
@@ -3,7 +3,7 @@ name: Validate Production Release
 on:
   pull_request:
     branches: [live-version-swa]
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read
@@ -17,9 +17,20 @@ jobs:
         env:
           HEAD_REF: ${{ github.head_ref }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
           TARGET_REPO: ${{ github.repository }}
         run: |
           if [ "$HEAD_REF" != "main" ] || [ "$HEAD_REPO" != "$TARGET_REPO" ]; then
             echo "::error::Production releases must originate from ${TARGET_REPO}:main"
+            exit 1
+          fi
+          if ! [[ "$PR_BODY" =~ approved-main-sha:([a-f0-9]{40}) ]]; then
+            echo "::error::Production release is missing an approved main SHA"
+            exit 1
+          fi
+          APPROVED_SHA="${BASH_REMATCH[1]}"
+          if [ "$HEAD_SHA" != "$APPROVED_SHA" ]; then
+            echo "::error::Main changed after approval. Expected $APPROVED_SHA but found $HEAD_SHA"
             exit 1
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,10 @@ gh workflow run release-production.yml
 The workflow opens a pull request from `main` into `live-version-swa` and enables merge-commit
 auto-merge. GitHub releases it after the required source, CI, CodeQL, and deployment-preview
 checks pass. Generated event and chapter pages use squash auto-merge into `main` but remain
-unreleased until this workflow is run.
+unreleased until approved. New chapter generation posts a Discord approval link bound to the
+exact tested `main` commit. An authenticated administrator can approve that release; if `main`
+changes first, the approval expires and the release is blocked. The manual workflow remains
+available for non-chapter releases.
 
 ## Tests
 

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -32,6 +32,7 @@ const sendAttendeeEmailHandler = require('./functions/sendAttendeeEmail');
 const getAuditLogHandler = require('./functions/getAuditLog');
 const registrationReportHandler = require('./functions/registrationReport');
 const postEventCommunicationHandler = require('./functions/postEventCommunication');
+const releaseApprovalHandler = require('./functions/releaseApproval');
 
 /**
  * Wraps a POST handler with CSRF header verification.
@@ -87,4 +88,9 @@ app.http('postEventCommunication', {
   methods: ['GET', 'POST'],
   authLevel: 'anonymous',
   handler: postEventCommunicationHandler
+});
+app.http('releaseApproval', {
+  methods: ['GET', 'POST'],
+  authLevel: 'anonymous',
+  handler: withCsrf(releaseApprovalHandler)
 });

--- a/api/src/functions/chapterApproval.js
+++ b/api/src/functions/chapterApproval.js
@@ -138,7 +138,8 @@ module.exports = async function (request, context) {
               linkedin: application.secondLeadLinkedIn || '',
               github: application.secondLeadGitHub || ''
             }),
-            discord_channel_id: discordChannel ? discordChannel.channelId : ''
+            discord_channel_id: discordChannel ? discordChannel.channelId : '',
+            notification_channel_id: process.env.DISCORD_NOTIFICATIONS_CHANNEL_ID || ''
           }
         });
         pageTriggered = true;

--- a/api/src/functions/releaseApproval.js
+++ b/api/src/functions/releaseApproval.js
@@ -1,0 +1,170 @@
+const { getAuthUser, hasRole, unauthorised, forbidden, extractEmail } = require('../helpers/auth');
+const { logAudit } = require('../helpers/auditLog');
+const { Octokit } = require('@octokit/rest');
+const { createAppAuth } = require('@octokit/auth-app');
+
+const SHA_PATTERN = /^[a-f0-9]{40}$/;
+const SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,60}[a-z0-9])?$/;
+
+function getGitHubClient() {
+  const appId = process.env.GITHUB_APP_ID;
+  const privateKey = (process.env.GITHUB_APP_PRIVATE_KEY || '').replace(/\\n/g, '\n');
+  const installationId = process.env.GITHUB_APP_INSTALLATION_ID;
+  const owner = process.env.GITHUB_REPO_OWNER;
+  const repo = process.env.GITHUB_REPO_NAME;
+
+  if (!appId || !privateKey || !installationId || !owner || !repo) {
+    throw new Error('GitHub App configuration is incomplete');
+  }
+
+  return {
+    owner,
+    repo,
+    octokit: new Octokit({
+      authStrategy: createAppAuth,
+      auth: { appId, privateKey, installationId }
+    })
+  };
+}
+
+function parseReleaseDetails(request, body) {
+  const url = new URL(request.url);
+  const sha = String(body?.sha || url.searchParams.get('sha') || '').toLowerCase();
+  const chapterSlug = String(body?.chapterSlug || url.searchParams.get('chapter') || '').toLowerCase();
+
+  if (!SHA_PATTERN.test(sha) || !SLUG_PATTERN.test(chapterSlug)) {
+    return null;
+  }
+  return { sha, chapterSlug };
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function confirmationPage(sha, chapterSlug) {
+  const owner = process.env.GITHUB_REPO_OWNER || 'Global-Security-Community';
+  const repo = process.env.GITHUB_REPO_NAME || 'core-website';
+  const reviewUrl = `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/compare/live-version-swa...${sha}`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Approve Production Release | Global Security Community</title>
+  <link rel="stylesheet" href="/css/style.css">
+  <script src="/js/release-approval.js" defer></script>
+</head>
+<body>
+  <main class="container">
+    <section class="card card-padding-standard">
+      <h1>Approve production release</h1>
+      <p>The generated <strong>${escapeHtml(chapterSlug)}</strong> chapter is ready on <code>main</code>.</p>
+      <p>This approval releases every tested change through commit <code>${escapeHtml(sha)}</code>.</p>
+      <p><a class="btn-secondary" href="${escapeHtml(reviewUrl)}" target="_blank" rel="noopener noreferrer">Review changes on GitHub</a></p>
+      <button
+        class="btn-primary"
+        id="approve-release"
+        type="button"
+        data-sha="${escapeHtml(sha)}"
+        data-chapter="${escapeHtml(chapterSlug)}"
+      >Approve release</button>
+      <p id="release-status" role="status" aria-live="polite"></p>
+    </section>
+  </main>
+</body>
+</html>`;
+}
+
+function jsonError(status, error) {
+  return {
+    status,
+    headers: { 'Content-Type': 'application/json', 'Cache-Control': 'private, no-store' },
+    jsonBody: { error }
+  };
+}
+
+/**
+ * GET/POST /api/releaseApproval
+ * Admin-only confirmation and dispatch for a SHA-bound production release.
+ */
+module.exports = async function releaseApproval(request, context) {
+  const user = getAuthUser(request);
+  if (!user) return unauthorised();
+  if (!hasRole(user, 'admin')) return forbidden('Only administrators can approve production releases');
+
+  if (request.method === 'GET') {
+    const details = parseReleaseDetails(request);
+    if (!details) {
+      return {
+        status: 400,
+        headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'private, no-store' },
+        body: '<h1>Invalid release request</h1><p>Use the approval link from Discord.</p>'
+      };
+    }
+    return {
+      status: 200,
+      headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'private, no-store' },
+      body: confirmationPage(details.sha, details.chapterSlug)
+    };
+  }
+
+  if (request.method !== 'POST') {
+    return jsonError(405, 'Method not allowed');
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, 'Invalid JSON');
+  }
+
+  const details = parseReleaseDetails(request, body);
+  if (!details) return jsonError(400, 'Invalid release SHA or chapter slug');
+
+  try {
+    const { octokit, owner, repo } = getGitHubClient();
+    const mainRef = await octokit.git.getRef({ owner, repo, ref: 'heads/main' });
+    const currentMainSha = mainRef.data.object.sha.toLowerCase();
+
+    if (currentMainSha !== details.sha) {
+      return jsonError(409, 'Main has changed since this approval was requested. Review the latest Discord request instead.');
+    }
+
+    const approvedBy = extractEmail(user) || user.userDetails || user.userId;
+    await octokit.repos.createDispatchEvent({
+      owner,
+      repo,
+      event_type: 'release-approved',
+      client_payload: {
+        expected_sha: details.sha,
+        chapter_slug: details.chapterSlug,
+        approved_by: 'authenticated administrator via Discord'
+      }
+    });
+
+    logAudit('release', details.sha, 'production_release_approved', approvedBy, {
+      chapterSlug: details.chapterSlug,
+      sha: details.sha
+    }, context);
+
+    return {
+      status: 202,
+      headers: { 'Cache-Control': 'private, no-store' },
+      jsonBody: {
+        success: true,
+        message: 'Release approved. Production checks are starting.'
+      }
+    };
+  } catch (error) {
+    context.log(`releaseApproval error: ${error.message}`);
+    return jsonError(500, 'Unable to start the production release');
+  }
+};

--- a/api/tests/octokit-integration.test.js
+++ b/api/tests/octokit-integration.test.js
@@ -266,13 +266,14 @@ describe('chapterApproval — GitHub dispatch integration', () => {
     expect(payload.chapter_slug).toBe('kansas-city');
   });
 
-  test('includes discord channel ID in dispatch payload', async () => {
+  test('includes Discord channel IDs in dispatch payload', async () => {
     setGitHubEnv();
     storage.getApplication.mockResolvedValueOnce({ ...pendingApplication });
     await chapterApproval(approvalReq({ id: 'app-1', action: 'approve', token: 'tok' }), context);
 
     const payload = mockCreateDispatchEvent.mock.calls[0][0].client_payload;
     expect(payload.discord_channel_id).toBe('ch-123');
+    expect(payload.notification_channel_id).toBe('test-notif-channel');
   });
 
   test('skips dispatch when GitHub env vars are missing', async () => {

--- a/api/tests/releaseApproval.test.js
+++ b/api/tests/releaseApproval.test.js
@@ -1,0 +1,141 @@
+const mockGetRef = jest.fn();
+const mockCreateDispatchEvent = jest.fn();
+const mockOctokit = jest.fn().mockImplementation(() => ({
+  git: { getRef: mockGetRef },
+  repos: { createDispatchEvent: mockCreateDispatchEvent }
+}));
+const mockCreateAppAuth = jest.fn();
+const mockLogAudit = jest.fn();
+
+jest.mock('@octokit/rest', () => ({ Octokit: mockOctokit }));
+jest.mock('@octokit/auth-app', () => ({ createAppAuth: mockCreateAppAuth }));
+jest.mock('../src/helpers/auditLog', () => ({ logAudit: mockLogAudit }));
+
+const releaseApproval = require('../src/functions/releaseApproval');
+
+const SHA = 'a'.repeat(40);
+const context = { log: jest.fn() };
+
+function request(method, roles = ['admin'], body, url = `https://example.com/api/releaseApproval?sha=${SHA}&chapter=perth`) {
+  const principal = Buffer.from(JSON.stringify({
+    userId: 'admin-id',
+    userDetails: 'admin@example.com',
+    userRoles: roles,
+    identityProvider: 'ciam'
+  })).toString('base64');
+
+  return {
+    method,
+    url,
+    headers: {
+      get(name) {
+        if (name === 'x-ms-client-principal') return principal;
+        if (name === 'x-requested-with') return 'fetch';
+        return null;
+      }
+    },
+    json: body instanceof Error
+      ? jest.fn().mockRejectedValue(body)
+      : jest.fn().mockResolvedValue(body || {})
+  };
+}
+
+describe('releaseApproval', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.GITHUB_APP_ID = 'app-id';
+    process.env.GITHUB_APP_PRIVATE_KEY = 'private-key';
+    process.env.GITHUB_APP_INSTALLATION_ID = 'installation-id';
+    process.env.GITHUB_REPO_OWNER = 'Global-Security-Community';
+    process.env.GITHUB_REPO_NAME = 'core-website';
+    mockGetRef.mockResolvedValue({ data: { object: { sha: SHA } } });
+    mockCreateDispatchEvent.mockResolvedValue({});
+  });
+
+  test('requires authentication', async () => {
+    const req = request('GET');
+    req.headers.get = () => null;
+    const response = await releaseApproval(req, context);
+    expect(response.status).toBe(401);
+  });
+
+  test('requires the admin role', async () => {
+    const response = await releaseApproval(request('GET', ['authenticated']), context);
+    expect(response.status).toBe(403);
+  });
+
+  test('renders a confirmation page for a valid request', async () => {
+    const response = await releaseApproval(request('GET'), context);
+    expect(response.status).toBe(200);
+    expect(response.body).toContain('Approve production release');
+    expect(response.body).toContain(SHA);
+    expect(response.body).toContain('/js/release-approval.js');
+    expect(response.headers['Cache-Control']).toBe('private, no-store');
+  });
+
+  test('rejects invalid release details', async () => {
+    const response = await releaseApproval(
+      request('GET', ['admin'], null, 'https://example.com/api/releaseApproval?sha=bad&chapter=Perth!'),
+      context
+    );
+    expect(response.status).toBe(400);
+  });
+
+  test('rejects malformed JSON', async () => {
+    const response = await releaseApproval(request('POST', ['admin'], new Error('bad json')), context);
+    expect(response.status).toBe(400);
+    expect(response.jsonBody.error).toBe('Invalid JSON');
+  });
+
+  test('rejects approval after main changes', async () => {
+    mockGetRef.mockResolvedValueOnce({ data: { object: { sha: 'b'.repeat(40) } } });
+    const response = await releaseApproval(
+      request('POST', ['admin'], { sha: SHA, chapterSlug: 'perth' }),
+      context
+    );
+    expect(response.status).toBe(409);
+    expect(mockCreateDispatchEvent).not.toHaveBeenCalled();
+  });
+
+  test('dispatches a SHA-bound release and records the approver', async () => {
+    const response = await releaseApproval(
+      request('POST', ['admin'], { sha: SHA, chapterSlug: 'perth' }),
+      context
+    );
+
+    expect(response.status).toBe(202);
+    expect(mockGetRef).toHaveBeenCalledWith({
+      owner: 'Global-Security-Community',
+      repo: 'core-website',
+      ref: 'heads/main'
+    });
+    expect(mockCreateDispatchEvent).toHaveBeenCalledWith({
+      owner: 'Global-Security-Community',
+      repo: 'core-website',
+      event_type: 'release-approved',
+      client_payload: {
+        expected_sha: SHA,
+        chapter_slug: 'perth',
+        approved_by: 'authenticated administrator via Discord'
+      }
+    });
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      'release',
+      SHA,
+      'production_release_approved',
+      'admin@example.com',
+      { chapterSlug: 'perth', sha: SHA },
+      context
+    );
+  });
+
+  test('surfaces GitHub dispatch failures', async () => {
+    mockCreateDispatchEvent.mockRejectedValueOnce(new Error('dispatch failed'));
+    const response = await releaseApproval(
+      request('POST', ['admin'], { sha: SHA, chapterSlug: 'perth' }),
+      context
+    );
+    expect(response.status).toBe(500);
+    expect(context.log).toHaveBeenCalledWith('releaseApproval error: dispatch failed');
+  });
+});

--- a/src/js/release-approval.js
+++ b/src/js/release-approval.js
@@ -1,0 +1,34 @@
+(function () {
+  'use strict';
+
+  var button = document.getElementById('approve-release');
+  var status = document.getElementById('release-status');
+  if (!button || !status) return;
+
+  button.addEventListener('click', async function () {
+    button.disabled = true;
+    status.textContent = 'Starting the protected production release...';
+
+    try {
+      var response = await fetch('/api/releaseApproval', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'fetch'
+        },
+        body: JSON.stringify({
+          sha: button.dataset.sha,
+          chapterSlug: button.dataset.chapter
+        })
+      });
+      var result = await response.json();
+      if (!response.ok) throw new Error(result.error || 'Release approval failed');
+
+      status.textContent = result.message;
+      button.textContent = 'Release approved';
+    } catch (error) {
+      status.textContent = error.message;
+      button.disabled = false;
+    }
+  });
+}());

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -184,6 +184,11 @@
       "headers": { "Cache-Control": "private, no-store" }
     },
     {
+      "route": "/api/releaseApproval",
+      "allowedRoles": ["admin"],
+      "headers": { "Cache-Control": "private, no-store" }
+    },
+    {
       "route": "/api/*",
       "allowedRoles": ["anonymous"],
       "headers": { "Cache-Control": "no-cache, no-store, must-revalidate" }


### PR DESCRIPTION
## Summary
- post a Discord release request after a generated chapter passes checks and squash-merges into `main`
- send administrators through CIAM to an admin-only confirmation page
- bind approval to the exact current `main` SHA and reject stale approvals
- dispatch the protected production release through the existing GitHub App
- persist the approved SHA in the release PR and revalidate it on PR edits and `main` updates
- retain the manual release workflow for non-chapter changes
- keep approver email only in the private audit log

## Security properties
- SWA `admin` route protection plus handler role enforcement
- CSRF-protected POST confirmation
- same-repository `main` source enforcement
- exact SHA checked by the API, release dispatcher, and required production source check
- later `main` changes invalidate approval before merge

## Validation
- zero production dependency audit findings
- 300 API tests
- Eleventy build and client script syntax
- API registry loading
- workflow YAML and SWA route validation