### PR TITLE
Improve platform email deliverability

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -312,6 +312,8 @@ API secrets are stored in `api/local.settings.json` (gitignored). Required value
 | `CIAM_CLIENT_ID` | Azure AD B2C app client ID |
 | `CIAM_CLIENT_SECRET` | Azure AD B2C app client secret |
 | `AZURE_COMMUNICATION_CONNECTION_STRING` | ACS connection (optional — emails fail gracefully) |
+| `ACS_REPLY_TO_ADDRESS` | Reply-to address for platform email (defaults to `hello@globalsecurity.community`) |
+| `EMAIL_UNSUBSCRIBE_SECRET` | Random secret used to sign one-click chapter unsubscribe links |
 | `SUPER_ADMIN_EMAILS` | Comma-separated community organiser addresses used for admin access and submission notifications |
 | `DISCORD_BOT_TOKEN` | Discord bot token (optional — notifications fail gracefully) |
 | `DISCORD_CONTACT_CHANNEL_ID` | Discord channel ID for contact form submissions |

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -14,6 +14,7 @@
         "@azure/storage-blob": "^12.31.0",
         "@octokit/auth-app": "^8.2.0",
         "@octokit/rest": "^22.0.1",
+        "html-to-text": "^9.0.5",
         "qrcode": "^1.5.4",
         "sanitize-html": "^2.17.4",
         "sharp": "^0.35.3"
@@ -2136,6 +2137,19 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
@@ -3554,6 +3568,53 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/html-to-text/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-to-text/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
@@ -4484,6 +4545,15 @@
         "dayjs": "^1.11.7"
       }
     },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -4802,6 +4872,19 @@
       "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
       "license": "MIT"
     },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4869,6 +4952,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5157,6 +5249,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/semver": {

--- a/api/package.json
+++ b/api/package.json
@@ -16,6 +16,7 @@
     "@azure/storage-blob": "^12.31.0",
     "@octokit/auth-app": "^8.2.0",
     "@octokit/rest": "^22.0.1",
+    "html-to-text": "^9.0.5",
     "qrcode": "^1.5.4",
     "sanitize-html": "^2.17.4",
     "sharp": "^0.35.3"

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -20,6 +20,7 @@ const getChapterHandler = require('./functions/getChapter');
 const refreshSessionizeHandler = require('./functions/refreshSessionize');
 const getSessionizeDataHandler = require('./functions/getSessionizeData');
 const chapterSubscribeHandler = require('./functions/chapterSubscribe');
+const chapterUnsubscribeHandler = require('./functions/chapterUnsubscribe');
 const communityPartnerHandler = require('./functions/communityPartner');
 const getCommunityPartnersHandler = require('./functions/getCommunityPartners');
 const chapterArtworkHandler = require('./functions/chapterArtwork');
@@ -53,6 +54,7 @@ app.get('getEvent', { authLevel: 'anonymous', handler: getEventHandler });
 app.get('getSessionizeData', { authLevel: 'anonymous', handler: getSessionizeDataHandler });
 app.get('getCommunityPartners', { authLevel: 'anonymous', handler: getCommunityPartnersHandler });
 app.get('chapterArtwork', { authLevel: 'anonymous', handler: chapterArtworkHandler });
+app.http('chapterUnsubscribe', { methods: ['GET', 'POST'], authLevel: 'anonymous', handler: chapterUnsubscribeHandler });
 
 // ─── Auth: role assignment (called by SWA platform — no CSRF check) ───
 app.post('roles', { authLevel: 'anonymous', handler: rolesHandler });

--- a/api/src/functions/chapterUnsubscribe.js
+++ b/api/src/functions/chapterUnsubscribe.js
@@ -1,0 +1,66 @@
+const { removeSubscription } = require('../helpers/tableStorage');
+const { verifyUnsubscribeToken } = require('../helpers/unsubscribeToken');
+
+function htmlResponse(status, title, message, token) {
+  const form = token && status === 200
+    ? `<form method="post">
+        <input type="hidden" name="List-Unsubscribe" value="One-Click">
+        <button type="submit">Unsubscribe</button>
+      </form>`
+    : '';
+
+  return {
+    status,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'private, no-store'
+    },
+    body: `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>${title}</title></head>
+<body>
+  <main>
+    <h1>${title}</h1>
+    <p>${message}</p>
+    ${form}
+  </main>
+</body>
+</html>`
+  };
+}
+
+/**
+ * GET/POST /api/chapterUnsubscribe
+ * Confirms or completes a signed RFC 8058 one-click unsubscribe request.
+ */
+module.exports = async function (request, context) {
+  let subscription;
+  try {
+    const token = new URL(request.url).searchParams.get('token');
+    subscription = verifyUnsubscribeToken(token);
+    if (!subscription) {
+      return htmlResponse(400, 'Invalid unsubscribe link', 'This unsubscribe link is invalid or has been changed.');
+    }
+
+    if (request.method === 'GET') {
+      return htmlResponse(
+        200,
+        'Unsubscribe from chapter updates',
+        'Confirm that you no longer want to receive new event announcements for this chapter.',
+        token
+      );
+    }
+
+    const body = new URLSearchParams(await request.text());
+    if (body.get('List-Unsubscribe') !== 'One-Click') {
+      return htmlResponse(400, 'Invalid unsubscribe request', 'The unsubscribe request was not in the expected format.');
+    }
+
+    await removeSubscription(subscription.chapterSlug, subscription.email);
+    context.log(`One-click unsubscribe completed for chapter ${subscription.chapterSlug}`);
+    return htmlResponse(200, 'You have been unsubscribed', 'You will no longer receive new event announcements for this chapter.');
+  } catch (error) {
+    context.log(`chapterUnsubscribe error: ${error.message}`);
+    return htmlResponse(500, 'Unable to unsubscribe', 'We could not update your subscription. Please try again later.');
+  }
+};

--- a/api/src/helpers/emailService.js
+++ b/api/src/helpers/emailService.js
@@ -333,10 +333,12 @@ async function sendCancellationEmail(registration, event, context) {
  * Sends a new event notification email to chapter subscribers.
  */
 async function sendEventNotificationEmail(subscriberEmail, event, context) {
+  if (!event.chapterSlug) {
+    throw new Error('Event chapter slug is required for chapter notification emails');
+  }
+
   const client = getEmailClient();
-  const chapterName = event.chapterSlug
-    ? event.chapterSlug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
-    : 'your chapter';
+  const chapterName = event.chapterSlug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 
   const eventPageUrl = event.slug ? `${SITE_URL}/events/${escapeHtml(event.slug)}/` : SITE_URL;
   const registerUrl = event.slug ? `${SITE_URL}/register/?event=${escapeHtml(event.slug)}` : SITE_URL;

--- a/api/src/helpers/emailService.js
+++ b/api/src/helpers/emailService.js
@@ -1,4 +1,5 @@
 const { EmailClient } = require('@azure/communication-email');
+const { convert: convertHtmlToText } = require('html-to-text');
 const { generateUnsubscribeToken } = require('./unsubscribeToken');
 
 const connectionString = process.env.AZURE_COMMUNICATION_CONNECTION_STRING || '';
@@ -47,41 +48,13 @@ function emailLayout(bodyHtml) {
 </html>`;
 }
 
-function decodeHtmlEntities(value) {
-  return value
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>')
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;|&apos;/gi, "'")
-    .replace(/&#(\d+);/g, (entity, code) => decodeCodePoint(entity, code, 10))
-    .replace(/&#x([0-9a-f]+);/gi, (entity, code) => decodeCodePoint(entity, code, 16));
-}
-
-function decodeCodePoint(entity, value, radix) {
-  const codePoint = parseInt(value, radix);
-  return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10FFFF
-    ? String.fromCodePoint(codePoint)
-    : entity;
-}
-
 function htmlToPlainText(html) {
-  const withoutTags = html
-    .replace(/<a\b[^>]*href=(["'])(.*?)\1[^>]*>(.*?)<\/a>/gis, (_, quote, href, label) => {
-      const text = label.replace(/<[^>]+>/g, '').trim();
-      return text && text !== href ? `${text} (${href})` : href;
-    })
-    .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/<li\b[^>]*>/gi, '- ')
-    .replace(/<\/(?:p|div|h[1-6]|li|tr|table)>/gi, '\n')
-    .replace(/<[^>]+>/g, '');
-
-  return decodeHtmlEntities(withoutTags)
-    .replace(/[ \t]+\n/g, '\n')
-    .replace(/\n[ \t]+/g, '\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
+  return convertHtmlToText(html, {
+    wordwrap: false,
+    selectors: [
+      { selector: 'img', format: 'skip' }
+    ]
+  }).trim();
 }
 
 function buildEmailContent(subject, bodyHtml) {

--- a/api/src/helpers/emailService.js
+++ b/api/src/helpers/emailService.js
@@ -59,7 +59,7 @@ function htmlToPlainText(html) {
 
 function buildEmailContent(subject, bodyHtml) {
   return {
-    subject,
+    subject: String(subject || '').replace(/[\r\n]+/g, ' ').trim(),
     plainText: `${htmlToPlainText(bodyHtml)}\n\nGlobal Security Community\n${SITE_URL}`,
     html: emailLayout(bodyHtml)
   };

--- a/api/src/helpers/emailService.js
+++ b/api/src/helpers/emailService.js
@@ -1,7 +1,9 @@
 const { EmailClient } = require('@azure/communication-email');
+const { generateUnsubscribeToken } = require('./unsubscribeToken');
 
 const connectionString = process.env.AZURE_COMMUNICATION_CONNECTION_STRING || '';
 const SENDER_ADDRESS = process.env.ACS_SENDER_ADDRESS || 'DoNotReply@globalsecurity.community';
+const REPLY_TO_ADDRESS = process.env.ACS_REPLY_TO_ADDRESS || 'hello@globalsecurity.community';
 const LOGO_URL = 'https://globalsecurity.community/assets/GSC-Shield-Transparent.png';
 const SITE_URL = 'https://globalsecurity.community';
 
@@ -43,6 +45,55 @@ function emailLayout(bodyHtml) {
   </div>
 </body>
 </html>`;
+}
+
+function decodeHtmlEntities(value) {
+  return value
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/&#(\d+);/g, (entity, code) => decodeCodePoint(entity, code, 10))
+    .replace(/&#x([0-9a-f]+);/gi, (entity, code) => decodeCodePoint(entity, code, 16));
+}
+
+function decodeCodePoint(entity, value, radix) {
+  const codePoint = parseInt(value, radix);
+  return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10FFFF
+    ? String.fromCodePoint(codePoint)
+    : entity;
+}
+
+function htmlToPlainText(html) {
+  const withoutTags = html
+    .replace(/<a\b[^>]*href=(["'])(.*?)\1[^>]*>(.*?)<\/a>/gis, (_, quote, href, label) => {
+      const text = label.replace(/<[^>]+>/g, '').trim();
+      return text && text !== href ? `${text} (${href})` : href;
+    })
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<li\b[^>]*>/gi, '- ')
+    .replace(/<\/(?:p|div|h[1-6]|li|tr|table)>/gi, '\n')
+    .replace(/<[^>]+>/g, '');
+
+  return decodeHtmlEntities(withoutTags)
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n[ \t]+/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function buildEmailContent(subject, bodyHtml) {
+  return {
+    subject,
+    plainText: `${htmlToPlainText(bodyHtml)}\n\nGlobal Security Community\n${SITE_URL}`,
+    html: emailLayout(bodyHtml)
+  };
+}
+
+function replyToRecipients() {
+  return [{ address: REPLY_TO_ADDRESS, displayName: 'Global Security Community' }];
 }
 
 /**
@@ -100,13 +151,11 @@ async function sendTicketEmail(registration, event, qrDataUrl, context, partners
 
   const message = {
     senderAddress: SENDER_ADDRESS,
-    content: {
-      subject: `Your Ticket: ${event.title}`,
-      html: emailLayout(bodyHtml)
-    },
+    content: buildEmailContent(`Your Ticket: ${event.title}`, bodyHtml),
     recipients: {
       to: [{ address: registration.email, displayName: registration.fullName }]
-    }
+    },
+    replyTo: replyToRecipients()
   };
 
   if (qrBase64) {
@@ -165,13 +214,11 @@ async function sendBadgeEmail(recipient, badgeContent, event, badgeType, context
 
   const message = {
     senderAddress: SENDER_ADDRESS,
-    content: {
-      subject: `Thank you for ${msg.roleText} ${event.title} — your ${badgeType} badge`,
-      html: emailLayout(bodyHtml)
-    },
+    content: buildEmailContent(`Thank you for ${msg.roleText} ${event.title} — your ${badgeType} badge`, bodyHtml),
     recipients: {
       to: [{ address: recipient.email, displayName: recipient.name }]
     },
+    replyTo: replyToRecipients(),
     attachments: [
       {
         name: attachmentName,
@@ -223,13 +270,11 @@ async function sendPostEventEmail(
     </p>`;
   const poller = await client.beginSend({
     senderAddress: SENDER_ADDRESS,
-    content: {
-      subject: subject.replace(/[\r\n]+/g, ' ').trim(),
-      html: emailLayout(bodyHtml)
-    },
+    content: buildEmailContent(subject.replace(/[\r\n]+/g, ' ').trim(), bodyHtml),
     recipients: {
       to: [{ address: recipient.email, displayName: recipient.name }]
     },
+    replyTo: replyToRecipients(),
     attachments: [{
       name: attachmentName,
       contentType,
@@ -292,13 +337,11 @@ async function sendCancellationEmail(registration, event, context) {
 
   const message = {
     senderAddress: SENDER_ADDRESS,
-    content: {
-      subject: `Registration Cancelled: ${event.title}`,
-      html: emailLayout(bodyHtml)
-    },
+    content: buildEmailContent(`Registration Cancelled: ${event.title}`, bodyHtml),
     recipients: {
       to: [{ address: registration.email, displayName: registration.fullName }]
-    }
+    },
+    replyTo: replyToRecipients()
   };
 
   try {
@@ -324,6 +367,8 @@ async function sendEventNotificationEmail(subscriberEmail, event, context) {
 
   const eventPageUrl = event.slug ? `${SITE_URL}/events/${escapeHtml(event.slug)}/` : SITE_URL;
   const registerUrl = event.slug ? `${SITE_URL}/register/?event=${escapeHtml(event.slug)}` : SITE_URL;
+  const unsubscribeToken = generateUnsubscribeToken(event.chapterSlug, subscriberEmail);
+  const unsubscribeUrl = `${SITE_URL}/api/chapterUnsubscribe?token=${encodeURIComponent(unsubscribeToken)}`;
 
   const bodyHtml = `
     <h2 style="color:#001f3f;margin:0 0 8px 0;">New Event: ${escapeHtml(event.title)} 🎉</h2>
@@ -337,17 +382,20 @@ async function sendEventNotificationEmail(subscriberEmail, event, context) {
     </p>
     <p style="color:#999;font-size:0.8em;text-align:center;margin-top:24px;">
       You received this because you subscribed to ${escapeHtml(chapterName)} chapter updates.
-      <a href="${SITE_URL}/chapters/${escapeHtml(event.chapterSlug)}/" style="color:#20b2aa;">Manage preferences</a>
+      <a href="${unsubscribeUrl}" style="color:#20b2aa;">Unsubscribe</a>
+      or <a href="${SITE_URL}/chapters/${escapeHtml(event.chapterSlug)}/" style="color:#20b2aa;">manage preferences</a>.
     </p>`;
 
   const message = {
     senderAddress: SENDER_ADDRESS,
-    content: {
-      subject: `New Event: ${event.title}`,
-      html: emailLayout(bodyHtml)
-    },
+    content: buildEmailContent(`New Event: ${event.title}`, bodyHtml),
     recipients: {
       to: [{ address: subscriberEmail }]
+    },
+    replyTo: replyToRecipients(),
+    headers: {
+      'List-Unsubscribe': `<${unsubscribeUrl}>`,
+      'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click'
     }
   };
 
@@ -380,13 +428,11 @@ async function sendAttendeeEmail(registration, event, subject, messageText, cont
 
   const emailMessage = {
     senderAddress: SENDER_ADDRESS,
-    content: {
-      subject: safeSubject,
-      html: emailLayout(bodyHtml)
-    },
+    content: buildEmailContent(safeSubject, bodyHtml),
     recipients: {
       to: [{ address: registration.email, displayName: registration.fullName }]
-    }
+    },
+    replyTo: replyToRecipients()
   };
 
   try {
@@ -428,13 +474,11 @@ async function sendSuperAdminEmail(subject, bodyHtml, context) {
   const results = await Promise.allSettled(recipients.map(async recipient => {
     const poller = await client.beginSend({
       senderAddress: SENDER_ADDRESS,
-      content: {
-        subject,
-        html: emailLayout(bodyHtml)
-      },
+      content: buildEmailContent(subject, bodyHtml),
       recipients: {
         to: [{ address: recipient }]
-      }
+      },
+      replyTo: replyToRecipients()
     });
     return ensureEmailSucceeded(await poller.pollUntilDone());
   }));

--- a/api/src/helpers/unsubscribeToken.js
+++ b/api/src/helpers/unsubscribeToken.js
@@ -1,0 +1,55 @@
+const crypto = require('crypto');
+
+function getSecret() {
+  const secret = process.env.EMAIL_UNSUBSCRIBE_SECRET || '';
+  if (!secret) {
+    throw new Error('EMAIL_UNSUBSCRIBE_SECRET environment variable is not configured');
+  }
+  return secret;
+}
+
+function normaliseSubscription(chapterSlug, email) {
+  return {
+    chapterSlug: String(chapterSlug || '').trim().toLowerCase(),
+    email: String(email || '').trim().toLowerCase()
+  };
+}
+
+function signPayload(payload) {
+  return crypto.createHmac('sha256', getSecret()).update(payload).digest('base64url');
+}
+
+function generateUnsubscribeToken(chapterSlug, email) {
+  const subscription = normaliseSubscription(chapterSlug, email);
+  if (!subscription.chapterSlug || !subscription.email) {
+    throw new Error('Chapter slug and subscriber email are required');
+  }
+
+  const payload = Buffer.from(JSON.stringify(subscription)).toString('base64url');
+  return `${payload}.${signPayload(payload)}`;
+}
+
+function verifyUnsubscribeToken(token) {
+  if (!token || typeof token !== 'string') return null;
+  const parts = token.split('.');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+
+  const [payload, signature] = parts;
+  const expected = signPayload(payload);
+  const providedBuffer = Buffer.from(signature, 'base64url');
+  const expectedBuffer = Buffer.from(expected, 'base64url');
+  if (providedBuffer.length !== expectedBuffer.length ||
+      !crypto.timingSafeEqual(providedBuffer, expectedBuffer)) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+    const subscription = normaliseSubscription(parsed.chapterSlug, parsed.email);
+    return subscription.chapterSlug && subscription.email ? subscription : null;
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { generateUnsubscribeToken, verifyUnsubscribeToken };

--- a/api/src/helpers/unsubscribeToken.js
+++ b/api/src/helpers/unsubscribeToken.js
@@ -1,5 +1,8 @@
 const crypto = require('crypto');
 
+const TOKEN_VERSION = 'v1';
+const IV_LENGTH = 12;
+
 function getSecret() {
   const secret = process.env.EMAIL_UNSUBSCRIBE_SECRET || '';
   if (!secret) {
@@ -15,8 +18,8 @@ function normaliseSubscription(chapterSlug, email) {
   };
 }
 
-function signPayload(payload) {
-  return crypto.createHmac('sha256', getSecret()).update(payload).digest('base64url');
+function encryptionKey() {
+  return crypto.createHash('sha256').update(getSecret(), 'utf8').digest();
 }
 
 function generateUnsubscribeToken(chapterSlug, email) {
@@ -25,26 +28,44 @@ function generateUnsubscribeToken(chapterSlug, email) {
     throw new Error('Chapter slug and subscriber email are required');
   }
 
-  const payload = Buffer.from(JSON.stringify(subscription)).toString('base64url');
-  return `${payload}.${signPayload(payload)}`;
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv('aes-256-gcm', encryptionKey(), iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(subscription), 'utf8'),
+    cipher.final()
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  return [
+    TOKEN_VERSION,
+    iv.toString('base64url'),
+    ciphertext.toString('base64url'),
+    authTag.toString('base64url')
+  ].join('.');
 }
 
 function verifyUnsubscribeToken(token) {
   if (!token || typeof token !== 'string') return null;
   const parts = token.split('.');
-  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
-
-  const [payload, signature] = parts;
-  const expected = signPayload(payload);
-  const providedBuffer = Buffer.from(signature, 'base64url');
-  const expectedBuffer = Buffer.from(expected, 'base64url');
-  if (providedBuffer.length !== expectedBuffer.length ||
-      !crypto.timingSafeEqual(providedBuffer, expectedBuffer)) {
+  if (parts.length !== 4 || parts.some(part => !part) || parts[0] !== TOKEN_VERSION) {
     return null;
   }
 
+  const [, encodedIv, encodedCiphertext, encodedAuthTag] = parts;
+  const iv = Buffer.from(encodedIv, 'base64url');
+  const ciphertext = Buffer.from(encodedCiphertext, 'base64url');
+  const authTag = Buffer.from(encodedAuthTag, 'base64url');
+  if (iv.length !== IV_LENGTH || !ciphertext.length || authTag.length !== 16) return null;
+
+  const key = encryptionKey();
   try {
-    const parsed = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+    const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+    decipher.setAuthTag(authTag);
+    const plaintext = Buffer.concat([
+      decipher.update(ciphertext),
+      decipher.final()
+    ]).toString('utf8');
+    const parsed = JSON.parse(plaintext);
     const subscription = normaliseSubscription(parsed.chapterSlug, parsed.email);
     return subscription.chapterSlug && subscription.email ? subscription : null;
   } catch {

--- a/api/tests/chapterUnsubscribe.test.js
+++ b/api/tests/chapterUnsubscribe.test.js
@@ -1,0 +1,66 @@
+const mockRemoveSubscription = jest.fn().mockResolvedValue({});
+const mockVerifyUnsubscribeToken = jest.fn();
+
+jest.mock('../src/helpers/tableStorage', () => ({ removeSubscription: mockRemoveSubscription }));
+jest.mock('../src/helpers/unsubscribeToken', () => ({ verifyUnsubscribeToken: mockVerifyUnsubscribeToken }));
+
+const chapterUnsubscribe = require('../src/functions/chapterUnsubscribe');
+
+describe('chapterUnsubscribe function', () => {
+  const context = { log: jest.fn() };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockVerifyUnsubscribeToken.mockReturnValue({
+      chapterSlug: 'perth',
+      email: 'user@example.com'
+    });
+  });
+
+  test('shows a confirmation page without changing the subscription on GET', async () => {
+    const response = await chapterUnsubscribe({
+      method: 'GET',
+      url: 'https://globalsecurity.community/api/chapterUnsubscribe?token=valid'
+    }, context);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toContain('Confirm that you no longer want');
+    expect(mockRemoveSubscription).not.toHaveBeenCalled();
+  });
+
+  test('removes the subscription for a valid one-click POST', async () => {
+    const response = await chapterUnsubscribe({
+      method: 'POST',
+      url: 'https://globalsecurity.community/api/chapterUnsubscribe?token=valid',
+      text: jest.fn().mockResolvedValue('List-Unsubscribe=One-Click')
+    }, context);
+
+    expect(response.status).toBe(200);
+    expect(mockRemoveSubscription).toHaveBeenCalledWith('perth', 'user@example.com');
+    expect(response.body).toContain('You have been unsubscribed');
+  });
+
+  test('rejects invalid tokens', async () => {
+    mockVerifyUnsubscribeToken.mockReturnValue(null);
+
+    const response = await chapterUnsubscribe({
+      method: 'POST',
+      url: 'https://globalsecurity.community/api/chapterUnsubscribe?token=invalid',
+      text: jest.fn().mockResolvedValue('List-Unsubscribe=One-Click')
+    }, context);
+
+    expect(response.status).toBe(400);
+    expect(mockRemoveSubscription).not.toHaveBeenCalled();
+  });
+
+  test('rejects non-standard POST bodies', async () => {
+    const response = await chapterUnsubscribe({
+      method: 'POST',
+      url: 'https://globalsecurity.community/api/chapterUnsubscribe?token=valid',
+      text: jest.fn().mockResolvedValue('confirm=yes')
+    }, context);
+
+    expect(response.status).toBe(400);
+    expect(mockRemoveSubscription).not.toHaveBeenCalled();
+  });
+});

--- a/api/tests/emailService.test.js
+++ b/api/tests/emailService.test.js
@@ -183,6 +183,21 @@ describe('superadmin email notifications', () => {
     expect(message.headers['List-Unsubscribe-Post']).toBe('List-Unsubscribe=One-Click');
   });
 
+  test('rejects chapter announcements without a chapter slug before delivery', async () => {
+    await expect(emailService.sendEventNotificationEmail(
+      'subscriber@example.com',
+      {
+        title: 'Security Meetup',
+        date: '2026-08-01',
+        location: 'Town Hall',
+        slug: 'security-meetup'
+      },
+      context
+    )).rejects.toThrow('Event chapter slug is required for chapter notification emails');
+
+    expect(mockBeginSend).not.toHaveBeenCalled();
+  });
+
   test('preserves escaped angle-bracket text in the plain-text alternative', async () => {
     await emailService.sendAttendeeEmail(
       { fullName: 'Alice', email: 'alice@example.com' },

--- a/api/tests/emailService.test.js
+++ b/api/tests/emailService.test.js
@@ -11,6 +11,7 @@ describe('superadmin email notifications', () => {
 
   beforeAll(() => {
     process.env.AZURE_COMMUNICATION_CONNECTION_STRING = 'endpoint=https://test/;accesskey=test';
+    process.env.EMAIL_UNSUBSCRIBE_SECRET = 'test-unsubscribe-secret';
     emailService = require('../src/helpers/emailService');
   });
 
@@ -23,6 +24,7 @@ describe('superadmin email notifications', () => {
 
   afterAll(() => {
     delete process.env.AZURE_COMMUNICATION_CONNECTION_STRING;
+    delete process.env.EMAIL_UNSUBSCRIBE_SECRET;
     delete process.env.SUPER_ADMIN_EMAILS;
   });
 
@@ -48,6 +50,11 @@ describe('superadmin email notifications', () => {
       expect(call[0].content.html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
       expect(call[0].content.html).toContain('&lt;b&gt;Build a community&lt;/b&gt;');
       expect(call[0].content.html).not.toContain('<script>');
+      expect(call[0].content.plainText).toContain('<script>alert(1)</script>');
+      expect(call[0].replyTo).toEqual([{
+        address: 'hello@globalsecurity.community',
+        displayName: 'Global Security Community'
+      }]);
     });
   });
 
@@ -153,5 +160,40 @@ describe('superadmin email notifications', () => {
     );
 
     expect(mockBeginSend.mock.calls[0][1]).toEqual({ operationId });
+  });
+
+  test('adds RFC 8058 one-click unsubscribe metadata to chapter announcements', async () => {
+    await emailService.sendEventNotificationEmail(
+      'subscriber@example.com',
+      {
+        title: 'Security Meetup',
+        date: '2026-08-01',
+        location: 'Town Hall',
+        slug: 'security-meetup',
+        chapterSlug: 'perth'
+      },
+      context
+    );
+
+    const message = mockBeginSend.mock.calls[0][0];
+    expect(message.content.plainText).toContain('Unsubscribe (https://globalsecurity.community/api/chapterUnsubscribe?token=');
+    expect(message.headers['List-Unsubscribe']).toMatch(
+      /^<https:\/\/globalsecurity\.community\/api\/chapterUnsubscribe\?token=/
+    );
+    expect(message.headers['List-Unsubscribe-Post']).toBe('List-Unsubscribe=One-Click');
+  });
+
+  test('preserves escaped angle-bracket text in the plain-text alternative', async () => {
+    await emailService.sendAttendeeEmail(
+      { fullName: 'Alice', email: 'alice@example.com' },
+      { title: 'C++ &lt;algorithm&gt;', date: '2026-08-01', location: 'Town Hall' },
+      'C++ update',
+      'Bring examples using <algorithm>.',
+      context
+    );
+
+    const message = mockBeginSend.mock.calls[0][0];
+    expect(message.content.plainText).toContain('C++ <algorithm>');
+    expect(message.content.plainText).toContain('Bring examples using <algorithm>.');
   });
 });

--- a/api/tests/emailService.test.js
+++ b/api/tests/emailService.test.js
@@ -183,6 +183,23 @@ describe('superadmin email notifications', () => {
     expect(message.headers['List-Unsubscribe-Post']).toBe('List-Unsubscribe=One-Click');
   });
 
+  test('normalises newlines from subjects across email types', async () => {
+    await emailService.sendEventNotificationEmail(
+      'subscriber@example.com',
+      {
+        title: 'Security Meetup\r\nBcc: victim@example.com',
+        date: '2026-08-01',
+        location: 'Town Hall',
+        slug: 'security-meetup',
+        chapterSlug: 'perth'
+      },
+      context
+    );
+
+    expect(mockBeginSend.mock.calls[0][0].content.subject)
+      .toBe('New Event: Security Meetup Bcc: victim@example.com');
+  });
+
   test('rejects chapter announcements without a chapter slug before delivery', async () => {
     await expect(emailService.sendEventNotificationEmail(
       'subscriber@example.com',

--- a/api/tests/emailService.test.js
+++ b/api/tests/emailService.test.js
@@ -176,7 +176,7 @@ describe('superadmin email notifications', () => {
     );
 
     const message = mockBeginSend.mock.calls[0][0];
-    expect(message.content.plainText).toContain('Unsubscribe (https://globalsecurity.community/api/chapterUnsubscribe?token=');
+    expect(message.content.plainText).toContain('Unsubscribe [https://globalsecurity.community/api/chapterUnsubscribe?token=');
     expect(message.headers['List-Unsubscribe']).toMatch(
       /^<https:\/\/globalsecurity\.community\/api\/chapterUnsubscribe\?token=/
     );
@@ -186,7 +186,7 @@ describe('superadmin email notifications', () => {
   test('preserves escaped angle-bracket text in the plain-text alternative', async () => {
     await emailService.sendAttendeeEmail(
       { fullName: 'Alice', email: 'alice@example.com' },
-      { title: 'C++ &lt;algorithm&gt;', date: '2026-08-01', location: 'Town Hall' },
+      { title: 'C++ <algorithm>', date: '2026-08-01', location: 'Town Hall' },
       'C++ update',
       'Bring examples using <algorithm>.',
       context

--- a/api/tests/unsubscribeToken.test.js
+++ b/api/tests/unsubscribeToken.test.js
@@ -17,11 +17,31 @@ describe('unsubscribe tokens', () => {
     });
   });
 
+  test('does not expose subscription data in the token', () => {
+    const { generateUnsubscribeToken } = require('../src/helpers/unsubscribeToken');
+    const token = generateUnsubscribeToken('perth', 'user@example.com');
+    const decodedParts = token.split('.').slice(1)
+      .map(part => Buffer.from(part, 'base64url').toString('utf8'))
+      .join('');
+
+    expect(token).toMatch(/^v1\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+    expect(decodedParts).not.toContain('perth');
+    expect(decodedParts).not.toContain('user@example.com');
+  });
+
+  test('uses a unique encrypted token for the same subscription', () => {
+    const { generateUnsubscribeToken } = require('../src/helpers/unsubscribeToken');
+
+    expect(generateUnsubscribeToken('perth', 'user@example.com'))
+      .not.toBe(generateUnsubscribeToken('perth', 'user@example.com'));
+  });
+
   test('rejects a token that has been changed', () => {
     const { generateUnsubscribeToken, verifyUnsubscribeToken } = require('../src/helpers/unsubscribeToken');
     const token = generateUnsubscribeToken('perth', 'user@example.com');
-    const [payload, signature] = token.split('.');
+    const parts = token.split('.');
+    parts[2] = `${parts[2].slice(0, -1)}${parts[2].endsWith('A') ? 'B' : 'A'}`;
 
-    expect(verifyUnsubscribeToken(`${payload}.${signature.slice(0, -1)}A`)).toBeNull();
+    expect(verifyUnsubscribeToken(parts.join('.'))).toBeNull();
   });
 });

--- a/api/tests/unsubscribeToken.test.js
+++ b/api/tests/unsubscribeToken.test.js
@@ -1,0 +1,27 @@
+describe('unsubscribe tokens', () => {
+  beforeAll(() => {
+    process.env.EMAIL_UNSUBSCRIBE_SECRET = 'test-unsubscribe-secret';
+  });
+
+  afterAll(() => {
+    delete process.env.EMAIL_UNSUBSCRIBE_SECRET;
+  });
+
+  test('round-trips a normalised subscription', () => {
+    const { generateUnsubscribeToken, verifyUnsubscribeToken } = require('../src/helpers/unsubscribeToken');
+    const token = generateUnsubscribeToken('Perth', 'User@Example.com');
+
+    expect(verifyUnsubscribeToken(token)).toEqual({
+      chapterSlug: 'perth',
+      email: 'user@example.com'
+    });
+  });
+
+  test('rejects a token that has been changed', () => {
+    const { generateUnsubscribeToken, verifyUnsubscribeToken } = require('../src/helpers/unsubscribeToken');
+    const token = generateUnsubscribeToken('perth', 'user@example.com');
+    const [payload, signature] = token.split('.');
+
+    expect(verifyUnsubscribeToken(`${payload}.${signature.slice(0, -1)}A`)).toBeNull();
+  });
+});

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -44,6 +44,11 @@
       "headers": { "Cache-Control": "public, max-age=86400, stale-while-revalidate=604800" }
     },
     {
+      "route": "/api/chapterUnsubscribe",
+      "allowedRoles": ["anonymous"],
+      "headers": { "Cache-Control": "private, no-store" }
+    },
+    {
       "route": "/dashboard/*",
       "allowedRoles": ["admin"],
       "headers": { "Cache-Control": "private, no-store" }


### PR DESCRIPTION
## Summary
- add plain-text alternatives and a branded reply-to address to platform emails
- add signed RFC 8058 one-click unsubscribe headers and a safe public unsubscribe endpoint for chapter announcements
- document the new email settings and protect the public unsubscribe route

## Operational changes completed
- provisioned `notifications@globalsecurity.community` in ACS with the Global Security Community display name
- configured `ACS_SENDER_ADDRESS`, `ACS_REPLY_TO_ADDRESS`, and `EMAIL_UNSUBSCRIBE_SECRET` in Azure Static Web Apps
- confirmed end-to-end delivery to the Google mailbox

## Validation
- 300 API tests passing
- `staticwebapp.config.json` parses successfully
- live ACS test message accepted and received