### PR TITLE
Prevent attendee email send timeouts

### DIFF
--- a/api/src/functions/resendTicketEmail.js
+++ b/api/src/functions/resendTicketEmail.js
@@ -4,6 +4,8 @@ const { sendTicketEmail } = require('../helpers/emailService');
 const { logAudit } = require('../helpers/auditLog');
 const { checkRateLimit, getClientIP } = require('../helpers/rateLimiter');
 
+const MAX_RECIPIENTS_PER_REQUEST = 15;
+
 /**
  * POST /api/resendTicketEmail
  * Admin-only: resend ticket confirmation emails to selected registrations.
@@ -27,15 +29,15 @@ module.exports = async function (request, context) {
                body: JSON.stringify({ error: 'Missing eventId or registrationIds (array)' }) };
     }
 
-    // Cap the number of emails per request
-    if (registrationIds.length > 100) {
+    // Keep each invocation comfortably below the Azure Functions timeout.
+    if (registrationIds.length > MAX_RECIPIENTS_PER_REQUEST) {
       return { status: 400, headers: { 'Content-Type': 'application/json' },
-               body: JSON.stringify({ error: 'Maximum 100 registrations per resend request' }) };
+               body: JSON.stringify({ error: `Maximum ${MAX_RECIPIENTS_PER_REQUEST} registrations per resend request` }) };
     }
 
-    // Rate limit: max 10 resend requests per admin per hour
+    // Smaller timeout-safe batches require more requests for a full event.
     const clientIP = getClientIP(request);
-    if (!checkRateLimit(clientIP, 'resendEmail', 10)) {
+    if (!checkRateLimit(clientIP, 'resendEmail', 20)) {
       return { status: 429, headers: { 'Content-Type': 'application/json' },
                body: JSON.stringify({ error: 'Too many resend requests. Please try again later.' }) };
     }

--- a/api/src/functions/sendAttendeeEmail.js
+++ b/api/src/functions/sendAttendeeEmail.js
@@ -62,7 +62,7 @@ module.exports = async function (request, context) {
     }
 
     const clientIP = getClientIP(request);
-    if (!checkRateLimit(clientIP, 'sendAttendeeEmail', 20)) {
+    if (!checkRateLimit(clientIP, 'sendAttendeeEmail', 30)) {
       return {
         status: 429,
         jsonBody: { error: 'Too many attendee email requests. Please try again later.' }

--- a/api/src/functions/sendAttendeeEmail.js
+++ b/api/src/functions/sendAttendeeEmail.js
@@ -11,6 +11,7 @@ const VALID_AUDIENCES = new Set([
   'volunteer-role',
   'volunteer-all'
 ]);
+const MAX_RECIPIENTS_PER_REQUEST = 15;
 
 /**
  * POST /api/sendAttendeeEmail
@@ -47,10 +48,10 @@ module.exports = async function (request, context) {
         jsonBody: { error: 'Event, recipients, subject, and message are required' }
       };
     }
-    if (registrationIds.length > 100) {
+    if (registrationIds.length > MAX_RECIPIENTS_PER_REQUEST) {
       return {
         status: 400,
-        jsonBody: { error: 'Maximum 100 recipients per request' }
+        jsonBody: { error: `Maximum ${MAX_RECIPIENTS_PER_REQUEST} recipients per request` }
       };
     }
     if (subject.length > 150 || message.length > 5000) {
@@ -61,7 +62,7 @@ module.exports = async function (request, context) {
     }
 
     const clientIP = getClientIP(request);
-    if (!checkRateLimit(clientIP, 'sendAttendeeEmail', 5)) {
+    if (!checkRateLimit(clientIP, 'sendAttendeeEmail', 20)) {
       return {
         status: 429,
         jsonBody: { error: 'Too many attendee email requests. Please try again later.' }

--- a/api/tests/functions-coverage.test.js
+++ b/api/tests/functions-coverage.test.js
@@ -739,15 +739,15 @@ describe('sendAttendeeEmail function', () => {
     expect(res.status).toBe(400);
   });
 
-  test('rejects more than 100 recipients', async () => {
+  test('rejects more than 15 recipients', async () => {
     const res = await sendAttendeeEmail(makeAuthRequest('POST', {
       eventId: 'ev-1',
-      registrationIds: Array.from({ length: 101 }, (_, index) => `r${index}`),
+      registrationIds: Array.from({ length: 16 }, (_, index) => `r${index}`),
       subject: 'Reminder',
       message: 'Remember the event'
     }, ['admin']), context);
     expect(res.status).toBe(400);
-    expect(res.jsonBody.error).toMatch(/Maximum 100/);
+    expect(res.jsonBody.error).toMatch(/Maximum 15/);
   });
 
   test('sends a sanitised custom message to selected registrations', async () => {

--- a/api/tests/functions-coverage.test.js
+++ b/api/tests/functions-coverage.test.js
@@ -659,6 +659,15 @@ describe('resendTicketEmail function', () => {
     expect(JSON.parse(res.body).error).toMatch(/registrationIds/);
   });
 
+  test('rejects more than 15 recipients', async () => {
+    const res = await resendTicketEmail(makeAuthRequest('POST', {
+      eventId: 'ev-1',
+      registrationIds: Array.from({ length: 16 }, (_, index) => `r${index}`)
+    }, ['admin']), context);
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/Maximum 15/);
+  });
+
   test('returns 400 when event not found', async () => {
     storage.getEventById.mockResolvedValueOnce(null);
     const res = await resendTicketEmail(makeAuthRequest('POST', { eventId: 'ev-1', registrationIds: ['r1'] }, ['admin']), context);

--- a/api/tests/unsubscribeToken.test.js
+++ b/api/tests/unsubscribeToken.test.js
@@ -40,7 +40,9 @@ describe('unsubscribe tokens', () => {
     const { generateUnsubscribeToken, verifyUnsubscribeToken } = require('../src/helpers/unsubscribeToken');
     const token = generateUnsubscribeToken('perth', 'user@example.com');
     const parts = token.split('.');
-    parts[2] = `${parts[2].slice(0, -1)}${parts[2].endsWith('A') ? 'B' : 'A'}`;
+    const ciphertext = Buffer.from(parts[2], 'base64url');
+    ciphertext[0] ^= 1;
+    parts[2] = ciphertext.toString('base64url');
 
     expect(verifyUnsubscribeToken(parts.join('.'))).toBeNull();
   });

--- a/src/js/dashboard.js
+++ b/src/js/dashboard.js
@@ -1312,6 +1312,7 @@
     btn.disabled = true;
     btn.textContent = 'Sending...';
 
+    // Must match MAX_RECIPIENTS_PER_REQUEST in resendTicketEmail.js.
     var batchSize = 15;
     var batches = [];
     for (var i = 0; i < ids.length; i += batchSize) {
@@ -1474,6 +1475,7 @@
     status.style.display = 'none';
 
     var batches = [];
+    // Must match MAX_RECIPIENTS_PER_REQUEST in sendAttendeeEmail.js.
     var batchSize = 15;
     for (var i = 0; i < registrationIds.length; i += batchSize) {
       batches.push(registrationIds.slice(i, i + batchSize));

--- a/src/js/dashboard.js
+++ b/src/js/dashboard.js
@@ -1430,16 +1430,18 @@
     status.style.display = 'none';
 
     var batches = [];
-    for (var i = 0; i < registrationIds.length; i += 100) {
-      batches.push(registrationIds.slice(i, i + 100));
+    var batchSize = 15;
+    for (var i = 0; i < registrationIds.length; i += batchSize) {
+      batches.push(registrationIds.slice(i, i + batchSize));
     }
     var result = { sent: 0, failed: 0 };
     var sendSequence = Promise.resolve();
 
     batches.forEach(function(batch, index) {
       sendSequence = sendSequence.then(function() {
-        status.textContent = batches.length > 1 ? 'Sending batch ' + (index + 1) + ' of ' + batches.length + '...' : '';
-        status.style.display = batches.length > 1 ? 'block' : 'none';
+        status.textContent = 'Sending batch ' + (index + 1) + ' of ' + batches.length + '... ' +
+          result.sent + ' confirmed sent so far.';
+        status.style.display = 'block';
         return GSC.fetch('/api/sendAttendeeEmail', {
           method: 'POST',
           headers: {'Content-Type':'application/json'},
@@ -1451,7 +1453,16 @@
             message: message
           })
         }).then(function(r) {
-          return r.json().then(function(data) {
+          return r.text().then(function(body) {
+            var data = {};
+            try {
+              data = body ? JSON.parse(body) : {};
+            } catch (error) {
+              if (!r.ok) {
+                throw new Error('The email service stopped before this batch completed. Some recipients in the current batch may have received the email; do not resend the full list.');
+              }
+              throw new Error('The email service returned an invalid response.');
+            }
             if (!r.ok) throw new Error(data.error || 'Failed to send emails.');
             result.sent += data.sent || 0;
             result.failed += data.failed || 0;
@@ -1471,7 +1482,7 @@
       loadAuditLog(eventId);
     })
     .catch(function(error) {
-      status.textContent = (result.sent ? result.sent + ' email(s) sent before an error occurred. ' : '') + error.message;
+      status.textContent = result.sent + ' email(s) confirmed sent before the error. ' + error.message;
       status.style.display = 'block';
     })
     .finally(function() {

--- a/src/js/dashboard.js
+++ b/src/js/dashboard.js
@@ -1312,27 +1312,71 @@
     btn.disabled = true;
     btn.textContent = 'Sending...';
 
-    GSC.fetch('/api/resendTicketEmail', {
-      method: 'POST', headers: {'Content-Type':'application/json'},
-      body: JSON.stringify({ eventId: eventId, registrationIds: ids })
-    })
-    .then(function(r) { return r.json(); })
-    .then(function(d) {
-      if (d.success) {
-        var msg = d.sent + ' email(s) sent.';
-        if (d.failed > 0) {
-          msg += ' ' + d.failed + ' failed.';
-          if (d.errors && d.errors.length > 0) {
-            msg += '\n\nErrors:\n' + d.errors.map(function(e) { return (e.email || e.id) + ': ' + e.error; }).join('\n');
-          }
+    var batchSize = 15;
+    var batches = [];
+    for (var i = 0; i < ids.length; i += batchSize) {
+      batches.push(ids.slice(i, i + batchSize));
+    }
+    var result = { sent: 0, failed: 0, errors: [] };
+    var sendSequence = Promise.resolve();
+
+    batches.forEach(function(batch, index) {
+      sendSequence = sendSequence.then(function() {
+        btn.textContent = 'Sending ' + (index + 1) + '/' + batches.length + '...';
+        return GSC.fetch('/api/resendTicketEmail', {
+          method: 'POST', headers: {'Content-Type':'application/json'},
+          body: JSON.stringify({ eventId: eventId, registrationIds: batch })
+        }).then(function(response) {
+          return parseEmailBatchResponse(
+            response,
+            'The ticket service stopped before this batch completed. Some recipients in the current batch may have received a ticket; do not resend the full list.'
+          );
+        }).then(function(data) {
+          result.sent += data.sent || 0;
+          result.failed += data.failed || 0;
+          if (data.errors) result.errors = result.errors.concat(data.errors);
+        });
+      });
+    });
+
+    sendSequence
+    .then(function() {
+      var msg = result.sent + ' ticket email(s) sent.';
+      if (result.failed > 0) {
+        msg += ' ' + result.failed + ' failed.';
+        if (result.errors.length > 0) {
+          msg += '\n\nErrors:\n' + result.errors.map(function(e) {
+            return (e.email || e.id) + ': ' + e.error;
+          }).join('\n');
         }
-        alert(msg);
-      } else {
-        alert(d.error || 'Failed to resend emails.');
       }
+      alert(msg);
     })
-    .catch(function() { alert('Network error.'); })
-    .finally(function() { btn.disabled = false; btn.textContent = 'Resend Tickets'; });
+    .catch(function(error) {
+      alert(result.sent + ' ticket email(s) confirmed sent before the error. ' + error.message);
+    })
+    .finally(function() {
+      btn.disabled = false;
+      btn.textContent = 'Resend Tickets';
+    });
+  }
+
+  function parseEmailBatchResponse(response, partialSendMessage) {
+    return response.text().then(function(body) {
+      var data = {};
+      try {
+        data = body ? JSON.parse(body) : {};
+      } catch (error) {
+        if (!response.ok) {
+          throw new Error(partialSendMessage);
+        }
+        throw new Error('The email service returned an invalid response.');
+      }
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to send emails.');
+      }
+      return data;
+    });
   }
 
   function showAttendeeEmailComposer() {
@@ -1452,18 +1496,11 @@
             subject: subject,
             message: message
           })
-        }).then(function(r) {
-          return r.text().then(function(body) {
-            var data = {};
-            try {
-              data = body ? JSON.parse(body) : {};
-            } catch (error) {
-              if (!r.ok) {
-                throw new Error('The email service stopped before this batch completed. Some recipients in the current batch may have received the email; do not resend the full list.');
-              }
-              throw new Error('The email service returned an invalid response.');
-            }
-            if (!r.ok) throw new Error(data.error || 'Failed to send emails.');
+        }).then(function(response) {
+          return parseEmailBatchResponse(
+            response,
+            'The email service stopped before this batch completed. Some recipients in the current batch may have received the email; do not resend the full list.'
+          ).then(function(data) {
             result.sent += data.sent || 0;
             result.failed += data.failed || 0;
           });


### PR DESCRIPTION
## Summary

- send attendee updates in 15-recipient batches so each Azure Functions invocation stays below the five-minute timeout
- send bulk ticket confirmations through the same timeout-safe batching flow
- increase admin request allowances to support smaller internal batches
- show confirmed progress while sending attendee updates and ticket resends
- handle non-JSON gateway failures with a clear partial-send warning instead of exposing a JSON parser error
- make encrypted unsubscribe-token tamper coverage deterministic across environments

## Incident findings

The production request on 31 July 2026 timed out after five minutes. ACS accepted 48 messages and ultimately delivered all 48 without a bounce. The remaining 90 registrations were resumed separately with ACS confirmation.

## Validation

- 313 API tests pass
- Eleventy production build passes
- dashboard JavaScript syntax check passes