### PR TITLE
Keep bulk email batches within gateway timeout

### DIFF
--- a/api/src/functions/resendTicketEmail.js
+++ b/api/src/functions/resendTicketEmail.js
@@ -3,8 +3,10 @@ const { getRegistrationsByEvent, getEventById, getPartnersByEvent } = require('.
 const { sendTicketEmail } = require('../helpers/emailService');
 const { logAudit } = require('../helpers/auditLog');
 const { checkRateLimit, getClientIP } = require('../helpers/rateLimiter');
+const { runInChunks } = require('../helpers/concurrency');
 
 const MAX_RECIPIENTS_PER_REQUEST = 15;
+const MAX_CONCURRENT_SENDS = 5;
 
 /**
  * POST /api/resendTicketEmail
@@ -63,11 +65,11 @@ module.exports = async function (request, context) {
     let sent = 0;
     const errors = [];
 
-    for (const regId of registrationIds) {
+    await runInChunks(registrationIds, MAX_CONCURRENT_SENDS, async regId => {
       const reg = regMap[regId];
       if (!reg) {
         errors.push({ id: regId, error: 'Registration not found' });
-        continue;
+        return;
       }
 
       // Build registration object matching sendTicketEmail expectations
@@ -94,7 +96,7 @@ module.exports = async function (request, context) {
         context.log(`Resend email failed for ${reg.email}: ${emailErr.message}`);
         errors.push({ id: regId, email: reg.email, error: 'Email send failed' });
       }
-    }
+    });
 
     context.log(`Resent ${sent}/${registrationIds.length} ticket emails for event ${eventId} by ${user.userDetails}`);
     logAudit('event', eventId, 'email_resent', user.userDetails, { sent, failed: errors.length, registrationIds }, context);

--- a/api/src/functions/sendAttendeeEmail.js
+++ b/api/src/functions/sendAttendeeEmail.js
@@ -4,6 +4,7 @@ const { sendAttendeeEmail } = require('../helpers/emailService');
 const { sanitiseFields } = require('../helpers/sanitise');
 const { logAudit } = require('../helpers/auditLog');
 const { checkRateLimit, getClientIP } = require('../helpers/rateLimiter');
+const { runInChunks } = require('../helpers/concurrency');
 
 const VALID_AUDIENCES = new Set([
   'selected',
@@ -12,6 +13,7 @@ const VALID_AUDIENCES = new Set([
   'volunteer-all'
 ]);
 const MAX_RECIPIENTS_PER_REQUEST = 15;
+const MAX_CONCURRENT_SENDS = 5;
 
 /**
  * POST /api/sendAttendeeEmail
@@ -87,15 +89,15 @@ module.exports = async function (request, context) {
     let sent = 0;
     const errors = [];
 
-    for (const registrationId of registrationIds) {
+    await runInChunks(registrationIds, MAX_CONCURRENT_SENDS, async registrationId => {
       const registration = registrationsById.get(registrationId);
       if (!registration) {
         errors.push({ id: registrationId, error: 'Registration not found' });
-        continue;
+        return;
       }
       if (!registrationMatchesAudience(registration, audience)) {
         errors.push({ id: registrationId, error: 'Registration is not part of the selected audience' });
-        continue;
+        return;
       }
 
       try {
@@ -108,7 +110,7 @@ module.exports = async function (request, context) {
         context.log(`Attendee email failed for ${registration.email}: ${emailError.message}`);
         errors.push({ id: registrationId, email: registration.email, error: 'Email send failed' });
       }
-    }
+    });
 
     logAudit('event', eventId, 'attendee_email_sent', user.userDetails, {
       subject,

--- a/api/src/helpers/concurrency.js
+++ b/api/src/helpers/concurrency.js
@@ -1,6 +1,12 @@
 async function runInChunks(items, chunkSize, handler) {
+  if (!Array.isArray(items)) throw new TypeError('items must be an array');
+  if (!Number.isInteger(chunkSize) || chunkSize <= 0) {
+    throw new RangeError('chunkSize must be a positive integer');
+  }
+  if (typeof handler !== 'function') throw new TypeError('handler must be a function');
+
   for (let index = 0; index < items.length; index += chunkSize) {
-    await Promise.all(items.slice(index, index + chunkSize).map(handler));
+    await Promise.all(items.slice(index, index + chunkSize).map(item => handler(item)));
   }
 }
 

--- a/api/src/helpers/concurrency.js
+++ b/api/src/helpers/concurrency.js
@@ -1,0 +1,7 @@
+async function runInChunks(items, chunkSize, handler) {
+  for (let index = 0; index < items.length; index += chunkSize) {
+    await Promise.all(items.slice(index, index + chunkSize).map(handler));
+  }
+}
+
+module.exports = { runInChunks };

--- a/api/tests/concurrency.test.js
+++ b/api/tests/concurrency.test.js
@@ -1,0 +1,31 @@
+const { runInChunks } = require('../src/helpers/concurrency');
+
+describe('runInChunks', () => {
+  test('limits concurrent work while processing every item', async () => {
+    let active = 0;
+    let maximumActive = 0;
+    const completed = [];
+
+    await runInChunks([1, 2, 3, 4, 5, 6, 7], 3, async item => {
+      active++;
+      maximumActive = Math.max(maximumActive, active);
+      await new Promise(resolve => setImmediate(resolve));
+      completed.push(item);
+      active--;
+    });
+
+    expect(maximumActive).toBe(3);
+    expect(completed).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  test('stops before starting another chunk when a handler rejects', async () => {
+    const started = [];
+
+    await expect(runInChunks([1, 2, 3], 2, async item => {
+      started.push(item);
+      if (item === 2) throw new Error('failed');
+    })).rejects.toThrow('failed');
+
+    expect(started).toEqual([1, 2]);
+  });
+});

--- a/api/tests/concurrency.test.js
+++ b/api/tests/concurrency.test.js
@@ -15,7 +15,7 @@ describe('runInChunks', () => {
     });
 
     expect(maximumActive).toBe(3);
-    expect(completed).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(completed.sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5, 6, 7]);
   });
 
   test('stops before starting another chunk when a handler rejects', async () => {
@@ -27,5 +27,14 @@ describe('runInChunks', () => {
     })).rejects.toThrow('failed');
 
     expect(started).toEqual([1, 2]);
+  });
+
+  test.each([
+    [null, 1, async () => {}],
+    [[], 0, async () => {}],
+    [[], 1.5, async () => {}],
+    [[], 1, null]
+  ])('rejects invalid arguments', async (items, chunkSize, handler) => {
+    await expect(runInChunks(items, chunkSize, handler)).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- process ticket resend batches with up to five concurrent ACS sends
- apply the same bounded concurrency to attendee information emails
- add coverage for concurrency limits and failure behavior

## Incident
The first 15-ticket production batch completed successfully in the Function after 84 seconds, but Azure Static Web Apps timed out the browser request before returning the success response. Bounded concurrency keeps each 15-recipient batch within the gateway deadline while avoiding an unbounded ACS burst.

## Testing
- `cd api && npm test -- --runInBand` (315 tests passed)