### PR TITLE
Fix volunteer ticket scanner access

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -9,6 +9,7 @@ const getEventHandler = require('./functions/getEvent');
 const registerEventHandler = require('./functions/registerEvent');
 const myTicketsHandler = require('./functions/myTickets');
 const checkInHandler = require('./functions/checkIn');
+const checkInStatsHandler = require('./functions/checkInStats');
 const issueBadgesHandler = require('./functions/issueBadges');
 const badgeDownloadHandler = require('./functions/badgeDownload');
 const eventAttendanceHandler = require('./functions/eventAttendance');
@@ -65,6 +66,7 @@ app.post('registerEvent', { authLevel: 'anonymous', handler: withCsrf(registerEv
 app.post('cancelRegistration', { authLevel: 'anonymous', handler: withCsrf(cancelRegistrationHandler) });
 app.get('myTickets', { authLevel: 'anonymous', handler: myTicketsHandler });
 app.get('badge', { authLevel: 'anonymous', handler: badgeDownloadHandler });
+app.get('checkInStats', { authLevel: 'anonymous', handler: checkInStatsHandler });
 app.post('chapterSubscribe', { authLevel: 'anonymous', handler: withCsrf(chapterSubscribeHandler) });
 
 // ─── Admin endpoints ───

--- a/api/src/functions/checkIn.js
+++ b/api/src/functions/checkIn.js
@@ -1,4 +1,4 @@
-const { getAuthUser, hasRole, unauthorised, forbidden, verifyChapterAccess } = require('../helpers/auth');
+const { getAuthUser, hasRole, unauthorised, forbidden, verifyEventCheckInAccess } = require('../helpers/auth');
 const { getRegistrationByTicketCode, updateRegistration, getEventById } = require('../helpers/tableStorage');
 const { logAudit } = require('../helpers/auditLog');
 
@@ -20,7 +20,8 @@ module.exports = async function (request, context) {
                body: JSON.stringify({ error: 'Invalid JSON' }) };
     }
 
-    const { ticketCode, eventId } = body;
+    const ticketCode = typeof body.ticketCode === 'string' ? body.ticketCode.trim().toUpperCase() : '';
+    const eventId = typeof body.eventId === 'string' ? body.eventId.trim() : '';
     if (!ticketCode || !eventId) {
       return { status: 400, headers: { 'Content-Type': 'application/json' },
                body: JSON.stringify({ error: 'Missing ticketCode or eventId' }) };
@@ -33,20 +34,20 @@ module.exports = async function (request, context) {
                body: JSON.stringify({ error: 'Event not found' }) };
     }
     const chapterSlug = event.chapterSlug || event.partitionKey || '';
-    if (!await verifyChapterAccess(user, chapterSlug, context)) {
+    if (!await verifyEventCheckInAccess(user, eventId, chapterSlug, context)) {
       return forbidden('You do not have permission to check in attendees for this event');
     }
 
     const registration = await getRegistrationByTicketCode(eventId, ticketCode);
     if (!registration) {
       return {
-        status: 404,
+        status: 400,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ error: 'Invalid ticket', status: 'invalid' })
       };
     }
 
-    if (registration.checkedIn) {
+    if (registration.checkedIn === true || registration.checkedIn === 'true') {
       return {
         status: 200,
         headers: { 'Content-Type': 'application/json' },

--- a/api/src/functions/checkInStats.js
+++ b/api/src/functions/checkInStats.js
@@ -1,0 +1,59 @@
+const {
+  getAuthUser,
+  hasRole,
+  unauthorised,
+  forbidden,
+  verifyEventCheckInAccess
+} = require('../helpers/auth');
+const { getEventById, getRegistrationsByEvent } = require('../helpers/tableStorage');
+
+/**
+ * GET /api/checkInStats?eventId={eventId}
+ * Returns privacy-safe scanner totals to authorised organisers and volunteers.
+ */
+module.exports = async function (request, context) {
+  try {
+    const user = getAuthUser(request);
+    if (!user) return unauthorised();
+    if (!hasRole(user, 'admin') && !hasRole(user, 'volunteer')) {
+      return forbidden('Only event organisers and volunteers can view check-in totals');
+    }
+
+    const eventId = new URL(request.url).searchParams.get('eventId')?.trim() || '';
+    if (!eventId) {
+      return {
+        status: 400,
+        jsonBody: { error: 'Missing eventId parameter' }
+      };
+    }
+
+    const event = await getEventById(eventId);
+    if (!event) {
+      return {
+        status: 400,
+        jsonBody: { error: 'Event not found' }
+      };
+    }
+
+    const chapterSlug = event.chapterSlug || event.partitionKey || '';
+    if (!await verifyEventCheckInAccess(user, eventId, chapterSlug, context)) {
+      return forbidden('You do not have permission to view check-in totals for this event');
+    }
+
+    const registrations = await getRegistrationsByEvent(eventId);
+    const checkedIn = registrations.filter(registration =>
+      registration.checkedIn === true || registration.checkedIn === 'true'
+    ).length;
+
+    return {
+      status: 200,
+      jsonBody: { total: registrations.length, checkedIn }
+    };
+  } catch (error) {
+    context.log(`checkInStats error: ${error.message}`);
+    return {
+      status: 500,
+      jsonBody: { error: 'Internal server error' }
+    };
+  }
+};

--- a/api/src/helpers/auth.js
+++ b/api/src/helpers/auth.js
@@ -113,7 +113,7 @@ async function resolveEmail(user) {
  * Returns true if: user is a super admin, OR user leads the target chapter.
  * Returns false otherwise.
  */
-async function verifyChapterAccess(user, targetChapterSlug, context) {
+async function verifyChapterAccess(user, targetChapterSlug, context, logDenied = true) {
   const email = await resolveEmail(user);
   if (isSuperAdmin(email)) {
     return true;
@@ -121,11 +121,33 @@ async function verifyChapterAccess(user, targetChapterSlug, context) {
   const slugs = await getAdminChapterSlugs(email);
   const target = (targetChapterSlug || '').toLowerCase();
   const hasAccess = slugs.includes(target);
-  if (!hasAccess && context) {
+  if (!hasAccess && context && logDenied) {
     const { logSecurityEvent } = require('./securityLogger');
     logSecurityEvent(context, 'chapter_access_denied', {
       email, targetChapter: target, userChapters: slugs
     });
+  }
+  return hasAccess;
+}
+
+async function verifyEventCheckInAccess(user, eventId, chapterSlug, context) {
+  if (hasRole(user, 'admin') && await verifyChapterAccess(user, chapterSlug, context, false)) {
+    return true;
+  }
+  if (!hasRole(user, 'admin') && !hasRole(user, 'volunteer')) return false;
+
+  const email = await resolveEmail(user);
+  if (!email) return false;
+  const {
+    isVolunteerOrOrganiserByRegistration,
+    isVolunteerForAnyEvent
+  } = require('./tableStorage');
+  const registration = await isVolunteerOrOrganiserByRegistration(email, eventId);
+  const hasAccess = Boolean(registration || await isVolunteerForAnyEvent(email, eventId));
+
+  if (!hasAccess && context) {
+    const { logSecurityEvent } = require('./securityLogger');
+    logSecurityEvent(context, 'event_check_in_access_denied', { email, eventId });
   }
   return hasAccess;
 }
@@ -169,4 +191,17 @@ function verifyCsrfHeader(request) {
   };
 }
 
-module.exports = { getAuthUser, hasRole, unauthorised, forbidden, verifyChapterAccess, getAdminChapterSlugs, isSuperAdmin, cityToSlug, verifyCsrfHeader, extractEmail, resolveEmail };
+module.exports = {
+  getAuthUser,
+  hasRole,
+  unauthorised,
+  forbidden,
+  verifyChapterAccess,
+  verifyEventCheckInAccess,
+  getAdminChapterSlugs,
+  isSuperAdmin,
+  cityToSlug,
+  verifyCsrfHeader,
+  extractEmail,
+  resolveEmail
+};

--- a/api/src/helpers/tableStorage.js
+++ b/api/src/helpers/tableStorage.js
@@ -203,6 +203,7 @@ async function storeRegistration(registration) {
     userId: registration.userId,
     fullName: registration.fullName,
     email: registration.email,
+    normalisedEmail: registration.email.trim().toLowerCase(),
     company: registration.company || '',
     ticketCode: registration.ticketCode,
     role: registration.role || 'attendee',
@@ -493,11 +494,14 @@ async function removeVolunteer(eventId, volunteerId) {
   await client.deleteEntity(eventId, volunteerId);
 }
 
-async function isVolunteerForAnyEvent(email) {
+async function isVolunteerForAnyEvent(email, eventId) {
   const client = getTableClient('EventVolunteers');
   const normalised = email.trim().toLowerCase();
+  const eventFilter = eventId
+    ? `PartitionKey eq '${eventId.replace(/'/g, "''")}' and `
+    : '';
   const entities = client.listEntities({
-    queryOptions: { filter: `email eq '${normalised.replace(/'/g, "''")}'` }
+    queryOptions: { filter: `${eventFilter}email eq '${normalised.replace(/'/g, "''")}'` }
   });
   for await (const entity of entities) {
     return entity;
@@ -514,15 +518,37 @@ async function getRegistrationsByRole(eventId, role) {
   return regs.filter(r => (r.role || 'attendee') === role);
 }
 
-async function isVolunteerOrOrganiserByRegistration(email) {
+async function isVolunteerOrOrganiserByRegistration(email, eventId) {
   const client = getTableClient('EventRegistrations');
   const normalised = email.trim().toLowerCase();
+  const eventFilter = eventId
+    ? `PartitionKey eq '${eventId.replace(/'/g, "''")}' and `
+    : '';
   const entities = client.listEntities({
-    queryOptions: { filter: `email eq '${normalised.replace(/'/g, "''")}'` }
+    queryOptions: { filter: `${eventFilter}normalisedEmail eq '${normalised.replace(/'/g, "''")}'` }
   });
   for await (const entity of entities) {
     const role = entity.role || 'attendee';
     if (role === 'volunteer' || role === 'organiser') return entity;
+  }
+
+  // Existing registrations predate normalisedEmail, so compare those records in code.
+  const legacyEntities = client.listEntities({
+    queryOptions: {
+      filter: eventId
+        ? `PartitionKey eq '${eventId.replace(/'/g, "''")}'`
+        : "(role eq 'volunteer' or role eq 'organiser')",
+      select: ['email', 'role']
+    }
+  });
+  for await (const entity of legacyEntities) {
+    const role = entity.role || 'attendee';
+    if (
+      String(entity.email || '').trim().toLowerCase() === normalised &&
+      (role === 'volunteer' || role === 'organiser')
+    ) {
+      return entity;
+    }
   }
   return null;
 }

--- a/api/tests/functions.test.js
+++ b/api/tests/functions.test.js
@@ -203,12 +203,12 @@ describe('checkIn function', () => {
     expect(res.status).toBe(403);
   });
 
-  test('returns 404 for invalid ticket', async () => {
+  test('returns JSON-safe 400 for invalid ticket', async () => {
     storage.getEventById.mockResolvedValueOnce({ rowKey: 'ev-1', partitionKey: 'perth', chapterSlug: 'perth' });
     storage.getRegistrationByTicketCode.mockResolvedValueOnce(null);
     const req = makeAuthRequest('POST', { ticketCode: 'INVALID', eventId: 'ev-1' }, ['admin']);
     const res = await checkIn(req, context);
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(400);
     expect(JSON.parse(res.body).status).toBe('invalid');
   });
 
@@ -241,6 +241,89 @@ describe('checkIn function', () => {
     expect(res.status).toBe(200);
     expect(JSON.parse(res.body).status).toBe('already_checked_in');
     expect(storage.updateRegistration).not.toHaveBeenCalled();
+  });
+
+  test('allows a volunteer assigned to this event to check in attendees', async () => {
+    storage.getEventById.mockResolvedValueOnce({ rowKey: 'ev-1', partitionKey: 'perth', chapterSlug: 'perth' });
+    storage.isVolunteerOrOrganiserByRegistration.mockResolvedValueOnce({ role: 'volunteer' });
+    storage.getRegistrationByTicketCode.mockResolvedValueOnce({
+      rowKey: 'reg-1',
+      fullName: 'Alice',
+      checkedIn: 'false'
+    });
+
+    const req = makeAuthRequest('POST', { ticketCode: 'abcd1234', eventId: 'ev-1' }, ['volunteer']);
+    const res = await checkIn(req, context);
+
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body).status).toBe('checked_in');
+    expect(storage.isVolunteerOrOrganiserByRegistration).toHaveBeenCalledWith('test@example.com', 'ev-1');
+    expect(storage.getRegistrationByTicketCode).toHaveBeenCalledWith('ev-1', 'ABCD1234');
+  });
+
+  test('rejects a volunteer who is not assigned to this event', async () => {
+    storage.getEventById.mockResolvedValueOnce({ rowKey: 'ev-1', partitionKey: 'perth', chapterSlug: 'perth' });
+    storage.isVolunteerOrOrganiserByRegistration.mockResolvedValueOnce(null);
+    storage.isVolunteerForAnyEvent.mockResolvedValueOnce(null);
+
+    const req = makeAuthRequest('POST', { ticketCode: 'ABCD1234', eventId: 'ev-1' }, ['volunteer']);
+    const res = await checkIn(req, context);
+
+    expect(res.status).toBe(403);
+    expect(storage.getRegistrationByTicketCode).not.toHaveBeenCalled();
+  });
+
+  test('allows a chapter admin volunteering at another chapter event', async () => {
+    storage.getApprovedApplicationsByEmail.mockResolvedValueOnce([{ city: 'Perth' }]);
+    storage.getEventById.mockResolvedValueOnce({ rowKey: 'ev-1', partitionKey: 'sydney', chapterSlug: 'sydney' });
+    storage.isVolunteerOrOrganiserByRegistration.mockResolvedValueOnce({ role: 'volunteer' });
+    storage.getRegistrationByTicketCode.mockResolvedValueOnce({
+      rowKey: 'reg-1',
+      fullName: 'Alice',
+      checkedIn: false
+    });
+
+    const req = makeAuthRequest('POST', { ticketCode: 'ABCD1234', eventId: 'ev-1' }, ['admin']);
+    const res = await checkIn(req, context);
+
+    expect(res.status).toBe(200);
+    expect(storage.isVolunteerOrOrganiserByRegistration).toHaveBeenCalledWith('test@example.com', 'ev-1');
+  });
+});
+
+describe('checkInStats function', () => {
+  const checkInStats = require('../src/functions/checkInStats');
+
+  beforeEach(() => jest.clearAllMocks());
+
+  test('returns privacy-safe totals with strict Table Storage booleans', async () => {
+    storage.getEventById.mockResolvedValueOnce({ rowKey: 'ev-1', partitionKey: 'perth', chapterSlug: 'perth' });
+    storage.getRegistrationsByEvent.mockResolvedValueOnce([
+      { rowKey: 'r1', checkedIn: true },
+      { rowKey: 'r2', checkedIn: 'true' },
+      { rowKey: 'r3', checkedIn: 'false' }
+    ]);
+    const req = makeAuthRequest('GET', null, ['admin']);
+    req.url = 'https://globalsecurity.community/api/checkInStats?eventId=ev-1';
+
+    const res = await checkInStats(req, context);
+
+    expect(res.status).toBe(200);
+    expect(res.jsonBody).toEqual({ total: 3, checkedIn: 2 });
+    expect(res.jsonBody.attendees).toBeUndefined();
+  });
+
+  test('allows an event volunteer to view totals', async () => {
+    storage.getEventById.mockResolvedValueOnce({ rowKey: 'ev-1', partitionKey: 'perth', chapterSlug: 'perth' });
+    storage.isVolunteerOrOrganiserByRegistration.mockResolvedValueOnce({ role: 'volunteer' });
+    storage.getRegistrationsByEvent.mockResolvedValueOnce([]);
+    const req = makeAuthRequest('GET', null, ['volunteer']);
+    req.url = 'https://globalsecurity.community/api/checkInStats?eventId=ev-1';
+
+    const res = await checkInStats(req, context);
+
+    expect(res.status).toBe(200);
+    expect(res.jsonBody).toEqual({ total: 0, checkedIn: 0 });
   });
 });
 

--- a/api/tests/tableStorageVolunteer.test.js
+++ b/api/tests/tableStorageVolunteer.test.js
@@ -1,0 +1,85 @@
+process.env.AZURE_STORAGE_CONNECTION_STRING = 'UseDevelopmentStorage=true';
+
+const mockClient = {
+  createEntity: jest.fn().mockResolvedValue({}),
+  listEntities: jest.fn()
+};
+
+jest.mock('@azure/data-tables', () => ({
+  TableClient: {
+    fromConnectionString: jest.fn(() => mockClient)
+  },
+  AzureNamedKeyCredential: jest.fn()
+}));
+
+const {
+  storeRegistration,
+  isVolunteerOrOrganiserByRegistration
+} = require('../src/helpers/tableStorage');
+
+function entities(values) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield* values;
+    }
+  };
+}
+
+describe('volunteer registration email matching', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('stores a normalised email alongside the original address', async () => {
+    await storeRegistration({
+      eventId: 'event-1',
+      id: 'registration-1',
+      userId: 'user-1',
+      fullName: 'Volunteer',
+      email: 'Volunteer@Example.COM',
+      ticketCode: 'TEST1234',
+      role: 'volunteer'
+    });
+
+    expect(mockClient.createEntity).toHaveBeenCalledWith(expect.objectContaining({
+      email: 'Volunteer@Example.COM',
+      normalisedEmail: 'volunteer@example.com'
+    }));
+  });
+
+  test('matches mixed-case email on a legacy event registration', async () => {
+    mockClient.listEntities
+      .mockReturnValueOnce(entities([]))
+      .mockReturnValueOnce(entities([{
+        partitionKey: 'event-1',
+        email: 'Volunteer@Example.COM',
+        role: 'volunteer'
+      }]));
+
+    const registration = await isVolunteerOrOrganiserByRegistration(
+      'volunteer@example.com',
+      'event-1'
+    );
+
+    expect(registration).toEqual(expect.objectContaining({ role: 'volunteer' }));
+    expect(mockClient.listEntities).toHaveBeenNthCalledWith(2, {
+      queryOptions: {
+        filter: "PartitionKey eq 'event-1'",
+        select: ['email', 'role']
+      }
+    });
+  });
+
+  test('limits the global legacy fallback to volunteer records and email fields', async () => {
+    mockClient.listEntities
+      .mockReturnValueOnce(entities([]))
+      .mockReturnValueOnce(entities([]));
+
+    await isVolunteerOrOrganiserByRegistration('volunteer@example.com');
+
+    expect(mockClient.listEntities).toHaveBeenNthCalledWith(2, {
+      queryOptions: {
+        filter: "(role eq 'volunteer' or role eq 'organiser')",
+        select: ['email', 'role']
+      }
+    });
+  });
+});

--- a/e2e/authenticated-flows.spec.js
+++ b/e2e/authenticated-flows.spec.js
@@ -84,5 +84,63 @@ test.describe('Authenticated Flows', () => {
     await expect(page.locator('h1')).toBeVisible();
     await docScreenshot(page, '14-scanner');
   });
-});
 
+  test('scanner handles valid, duplicate, and invalid manual ticket codes', async ({ page }) => {
+    let validScans = 0;
+    const submittedCodes = [];
+
+    await page.route('**/js/vendor/html5-qrcode.min.js*', route => route.fulfill({
+      contentType: 'application/javascript',
+      body: `window.Html5Qrcode = class {
+        start() { return Promise.resolve(); }
+        pause() {}
+        resume() {}
+      };`
+    }));
+    await page.route('**/api/checkInStats?**', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ total: 137, checkedIn: 0 })
+    }));
+    await page.route('**/api/checkIn', async route => {
+      const requestBody = route.request().postDataJSON();
+      submittedCodes.push(requestBody.ticketCode);
+      if (requestBody.ticketCode === 'TEST1234') {
+        validScans++;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(validScans === 1
+            ? { status: 'checked_in', attendeeName: 'Scanner Test' }
+            : { status: 'already_checked_in', attendeeName: 'Scanner Test', checkedInAt: '2026-07-31T05:00:00Z' })
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 400,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'invalid', error: 'Invalid ticket' })
+      });
+    });
+
+    await page.goto('/scanner/');
+    await page.locator('#scanner-event-id').fill('event-test');
+    await page.locator('#start-scanner-btn').click();
+    await expect(page.locator('#scan-registered')).toHaveText('137');
+
+    await page.locator('#manual-code').fill('test1234');
+    await page.locator('#manual-checkin-btn').click();
+    await expect(page.locator('#scan-result')).toContainText('Scanner Test checked in!');
+    await expect(page.locator('#scan-total')).toHaveText('1');
+
+    await page.locator('#manual-code').fill('TEST1234');
+    await page.locator('#manual-checkin-btn').click();
+    await expect(page.locator('#scan-result')).toContainText('already checked in');
+    await expect(page.locator('#scan-total')).toHaveText('1');
+
+    await page.locator('#manual-code').fill('invalid');
+    await page.locator('#manual-checkin-btn').click();
+    await expect(page.locator('#scan-result')).toContainText('Invalid ticket code');
+    expect(submittedCodes).toEqual(['TEST1234', 'TEST1234', 'INVALID']);
+  });
+});

--- a/src/js/scanner.js
+++ b/src/js/scanner.js
@@ -35,7 +35,7 @@
   });
 
   document.getElementById('manual-checkin-btn').addEventListener('click', function() {
-    var code = document.getElementById('manual-code').value.trim();
+    var code = document.getElementById('manual-code').value.trim().toUpperCase();
     if (code) {
       doCheckIn(code);
       document.getElementById('manual-code').value = '';
@@ -66,7 +66,14 @@
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ ticketCode: ticketCode, eventId: eventId })
     })
-    .then(function(r) { return r.json(); })
+    .then(function(r) {
+      return r.json().then(function(data) {
+        if (!r.ok && data.status !== 'invalid') {
+          throw new Error(data.error || 'Check-in failed.');
+        }
+        return data;
+      });
+    })
     .then(function(data) {
       scanLog.unshift({ code: ticketCode, time: Date.now(), result: data.status, name: data.attendeeName || '' });
 
@@ -85,15 +92,20 @@
 
       renderLog();
     })
-    .catch(function() {
+    .catch(function(error) {
       resultEl.style.backgroundColor = '#f8d7da'; resultEl.style.color = '#721c24';
-      resultEl.textContent = 'Network error. Please try again.';
+      resultEl.textContent = error.message || 'Network error. Please try again.';
     });
   }
 
   function loadStats() {
-    GSC.fetch('/api/eventAttendance?eventId=' + encodeURIComponent(eventId))
-      .then(function(r) { return r.json(); })
+    GSC.fetch('/api/checkInStats?eventId=' + encodeURIComponent(eventId))
+      .then(function(r) {
+        return r.json().then(function(data) {
+          if (!r.ok) throw new Error(data.error || 'Unable to load check-in totals.');
+          return data;
+        });
+      })
       .then(function(data) {
         totalRegistered = data.total || 0;
         totalCheckedIn = data.checkedIn || 0;

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -79,6 +79,11 @@
       "headers": { "Cache-Control": "private, no-store" }
     },
     {
+      "route": "/api/checkInStats",
+      "allowedRoles": ["admin", "volunteer"],
+      "headers": { "Cache-Control": "private, no-store" }
+    },
+    {
       "route": "/api/issueBadges",
       "allowedRoles": ["admin"],
       "headers": { "Cache-Control": "private, no-store" }


### PR DESCRIPTION
## Summary
- authorize scanner volunteers only for events where they are registered as volunteer/organiser, while preserving chapter-admin access
- add a privacy-safe check-in totals endpoint available to organisers and event volunteers
- keep invalid-ticket responses as JSON-safe HTTP 400 rather than SWA-rewritten 404 responses
- normalize manual ticket codes, Table Storage booleans, and mixed-case volunteer email matching
- surface scanner API authorization/errors clearly

## Validation
- `cd api && npm test -- --runInBand` (327 tests passed)
- `npm run build`
- Playwright scanner flow: valid check-in, duplicate scan, lowercase manual code, and invalid ticket
- read-only production validation used; no attendee was checked in