### PR TITLE
Validate event slugs and resolve dependency alerts

### DIFF
--- a/.github/workflows/generate-event.yml
+++ b/.github/workflows/generate-event.yml
@@ -53,8 +53,8 @@ jobs:
           CHAPTER_SLUG: ${{ github.event.client_payload.chapter_slug }}
         run: |
           # Validate slug format (alphanumeric and hyphens only)
-          if ! [[ "$SLUG" =~ ^[a-z0-9][a-z0-9-]{0,60}[a-z0-9]$ ]]; then
-            echo "::error::Invalid event slug format: must be lowercase alphanumeric with hyphens"
+          if ! [[ "$SLUG" =~ ^[a-z0-9][a-z0-9-]{0,78}[a-z0-9]$ ]]; then
+            echo "::error::Invalid event slug format: must be at most 80 lowercase alphanumeric characters and hyphens"
             exit 1
           fi
           if ! [[ "$CHAPTER_SLUG" =~ ^[a-z0-9][a-z0-9-]{0,60}[a-z0-9]$ ]]; then

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2796,9 +2796,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4475,9 +4475,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4682,9 +4682,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -5596,9 +5596,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/api/src/functions/createEvent.js
+++ b/api/src/functions/createEvent.js
@@ -10,6 +10,16 @@ const { logAudit } = require('../helpers/auditLog');
 const { Octokit } = require('@octokit/rest');
 const { createAppAuth } = require('@octokit/auth-app');
 
+const MAX_EVENT_SLUG_LENGTH = 80;
+const EVENT_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,78}[a-z0-9])?$/;
+
+function appendSlugSuffix(slug, suffix) {
+  const cleanSuffix = String(suffix).replace(/[^a-z0-9]/g, '');
+  const availableBaseLength = MAX_EVENT_SLUG_LENGTH - cleanSuffix.length - 1;
+  const base = slug.substring(0, availableBaseLength).replace(/-+$/g, '');
+  return `${base}-${cleanSuffix}`;
+}
+
 module.exports = async function (request, context) {
   context.log('Create event request received');
 
@@ -86,19 +96,26 @@ module.exports = async function (request, context) {
       .replace(/[^a-z0-9\s-]/g, '')
       .replace(/\s+/g, '-')
       .replace(/-+/g, '-')
-      .substring(0, 80);
+      .replace(/^-+|-+$/g, '')
+      .substring(0, MAX_EVENT_SLUG_LENGTH)
+      .replace(/-+$/g, '');
+
+    if (!EVENT_SLUG_PATTERN.test(slug)) {
+      return { status: 400, headers: { 'Content-Type': 'application/json' },
+               body: JSON.stringify({ error: 'Event title must contain at least one letter or number' }) };
+    }
 
     // Ensure slug uniqueness — append city or counter if needed
     if (await getEventBySlug(slug)) {
       const citySlug = (safe.locationCity || '').toLowerCase().replace(/[^a-z0-9]/g, '');
       if (citySlug && !slug.includes(citySlug)) {
-        slug = (slug + '-' + citySlug).substring(0, 80);
+        slug = appendSlugSuffix(slug, citySlug.substring(0, MAX_EVENT_SLUG_LENGTH - 2));
       }
       // If still not unique, append a counter
       let counter = 2;
       let candidate = slug;
       while (await getEventBySlug(candidate)) {
-        candidate = slug + '-' + counter;
+        candidate = appendSlugSuffix(slug, counter);
         counter++;
       }
       slug = candidate;

--- a/api/tests/functions-coverage.test.js
+++ b/api/tests/functions-coverage.test.js
@@ -993,6 +993,41 @@ describe('createEvent function', () => {
     const body = JSON.parse(res.body);
     expect(body.event.slug).toBe('global-security-bootcamp-2026');
   });
+
+  test('creates workflow-compatible slugs up to 80 characters', async () => {
+    const res = await createEvent(makeAuthRequest('POST', {
+      ...validBody,
+      title: 'Securing Agentic AI: How to Build, Deploy, and Govern Trustworthy AI Agents'
+    }, ['admin']), context);
+    expect(res.status).toBe(201);
+    const slug = JSON.parse(res.body).event.slug;
+    expect(slug).toBe('securing-agentic-ai-how-to-build-deploy-and-govern-trustworthy-ai-agents');
+    expect(slug.length).toBeLessThanOrEqual(80);
+  });
+
+  test('rejects a title that cannot produce a valid slug', async () => {
+    const res = await createEvent(makeAuthRequest('POST', {
+      ...validBody, title: '!!!'
+    }, ['admin']), context);
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/letter or number/);
+    expect(storage.storeEvent).not.toHaveBeenCalled();
+  });
+
+  test('keeps uniqueness suffixes within the workflow slug limit', async () => {
+    storage.getEventBySlug
+      .mockResolvedValueOnce({ rowKey: 'existing' })
+      .mockResolvedValueOnce({ rowKey: 'existing-in-city' })
+      .mockResolvedValueOnce(null);
+
+    const res = await createEvent(makeAuthRequest('POST', {
+      ...validBody, title: 'A'.repeat(100)
+    }, ['admin']), context);
+    expect(res.status).toBe(201);
+    const slug = JSON.parse(res.body).event.slug;
+    expect(slug).toHaveLength(80);
+    expect(slug).toMatch(/-2$/);
+  });
 });
 
 // ─── issueBadges ────────────────────────────────────────────────────

--- a/package-lock.json
+++ b/package-lock.json
@@ -1432,9 +1432,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2940,9 +2940,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -3549,9 +3549,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "tmp": "^0.2.4",
     "ws": "^8.20.1",
     "adm-zip": "0.6.0",
-    "brace-expansion": "5.0.8"
+    "brace-expansion": "5.0.9"
   }
 }

--- a/src/dashboard/index.md
+++ b/src/dashboard/index.md
@@ -224,7 +224,7 @@ title: Dashboard
       <div class="form-group">
         <label for="edit-slug">URL Slug *</label>
         <input type="text" id="edit-slug" maxlength="80" placeholder="e.g. my-event-name">
-        <span class="help-text">Only lowercase letters, numbers, and hyphens. Changing this will alter the event URL.</span>
+        <span class="help-text">Maximum 80 lowercase letters, numbers, and hyphens. Changing this will alter the event URL.</span>
       </div>
       <div class="form-group">
         <label for="edit-date">Date *</label>


### PR DESCRIPTION
Long event titles could generate slugs rejected by the page-generation workflow, leaving stored events without a published page. The same CI path was also blocked by newly disclosed high-severity dependency alerts.

## Changes
- Align event creation and workflow validation on an 80-character slug contract.
- Validate generated slugs before storage and keep city/counter uniqueness suffixes within the limit.
- Add regression coverage for long titles, invalid titles, and uniqueness suffixes.
- Update vulnerable `brace-expansion`, `js-yaml`, and `nanoid` transitive dependencies across both lockfiles.
- Clarify the event slug limit in the dashboard.

Both root and API dependency audits now report zero vulnerabilities.