### PR TITLE
Streamline scanner, speaker, and chapter workflows

### DIFF
--- a/.github/workflows/update-chapter.yml
+++ b/.github/workflows/update-chapter.yml
@@ -1,0 +1,93 @@
+name: Update Chapter Page
+
+on:
+  repository_dispatch:
+    types: [chapter-updated]
+
+permissions:
+  contents: write
+  actions: write
+  pull-requests: write
+
+concurrency:
+  group: update-chapter-${{ github.event.client_payload.chapter_slug }}
+  cancel-in-progress: false
+
+jobs:
+  update-chapter:
+    runs-on: ubuntu-latest
+    env:
+      CITY: ${{ github.event.client_payload.chapter_city }}
+      SLUG: ${{ github.event.client_payload.chapter_slug }}
+      MARKDOWN_BASE64: ${{ github.event.client_payload.chapter_markdown_base64 }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Validate update payload
+        run: |
+          if ! [[ "$SLUG" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+            echo "::error::Invalid chapter slug"
+            exit 1
+          fi
+          if [ -z "$CITY" ] || [ -z "$MARKDOWN_BASE64" ]; then
+            echo "::error::Chapter city and content are required"
+            exit 1
+          fi
+
+      - name: Create chapter update branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          mkdir -p "src/chapters/${SLUG}"
+          printf '%s' "$MARKDOWN_BASE64" | base64 --decode > "src/chapters/${SLUG}/index.md"
+          git add "src/chapters/${SLUG}/index.md"
+
+          if git diff --cached --quiet; then
+            echo "No chapter page changes to publish"
+            exit 0
+          fi
+
+          BRANCH="auto/update-chapter-${SLUG}-${GITHUB_RUN_ID}"
+          git checkout -b "$BRANCH"
+          git commit -m "Update chapter page for ${CITY}
+
+          Updated from the chapter dashboard.
+
+          Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>"
+          git push origin "$BRANCH"
+          echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
+
+      - name: Open PR and enable auto-merge
+        if: env.BRANCH != ''
+        env:
+          GH_TOKEN: ${{ secrets.GH_PR_TOKEN }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Update chapter page for ${CITY}" \
+            --body "Automated chapter lead and profile update from the admin dashboard."
+          PR_NUMBER=$(gh pr view "$BRANCH" --json number -q .number)
+
+          GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" gh workflow run ci.yml --ref "$BRANCH"
+          gh pr merge "$PR_NUMBER" --auto --squash
+
+          echo "Waiting for PR #$PR_NUMBER to merge..."
+          for i in $(seq 1 40); do
+            STATE=$(gh pr view "$PR_NUMBER" --json state -q .state)
+            if [ "$STATE" = "MERGED" ]; then
+              echo "PR #$PR_NUMBER merged"
+              exit 0
+            fi
+            if [ "$STATE" = "CLOSED" ]; then
+              echo "::error::PR #$PR_NUMBER was closed without merging"
+              exit 1
+            fi
+            sleep 15
+          done
+          echo "::error::Timed out waiting for PR #$PR_NUMBER to merge"
+          exit 1

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -35,6 +35,7 @@ const getAuditLogHandler = require('./functions/getAuditLog');
 const registrationReportHandler = require('./functions/registrationReport');
 const postEventCommunicationHandler = require('./functions/postEventCommunication');
 const releaseApprovalHandler = require('./functions/releaseApproval');
+const scannerEventsHandler = require('./functions/scannerEvents');
 
 /**
  * Wraps a POST handler with CSRF header verification.
@@ -67,6 +68,7 @@ app.post('cancelRegistration', { authLevel: 'anonymous', handler: withCsrf(cance
 app.get('myTickets', { authLevel: 'anonymous', handler: myTicketsHandler });
 app.get('badge', { authLevel: 'anonymous', handler: badgeDownloadHandler });
 app.get('checkInStats', { authLevel: 'anonymous', handler: checkInStatsHandler });
+app.get('scannerEvents', { authLevel: 'anonymous', handler: scannerEventsHandler });
 app.post('chapterSubscribe', { authLevel: 'anonymous', handler: withCsrf(chapterSubscribeHandler) });
 
 // ─── Admin endpoints ───

--- a/api/src/functions/adminRegister.js
+++ b/api/src/functions/adminRegister.js
@@ -4,10 +4,81 @@ const { getEventById, storeRegistration, getRegistrationsByEvent, VALID_ROLES } 
 const { stripHtml } = require('../helpers/sanitise');
 const { sendTicketEmail } = require('../helpers/emailService');
 const { logAudit } = require('../helpers/auditLog');
+const { runInChunks } = require('../helpers/concurrency');
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const BULK_LIMIT = 50;
+
+function jsonResponse(status, body) {
+  return {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  };
+}
+
+function normalisePerson(name, email) {
+  return {
+    name: stripHtml(String(name || '')).trim(),
+    email: stripHtml(String(email || '')).trim()
+  };
+}
+
+async function createRegistration({ eventId, name, email, role }, event, user, context) {
+  const ticketCode = randomBytes(5).toString('hex').substring(0, 8).toUpperCase();
+  const registrationId = randomUUID();
+  const registration = {
+    id: registrationId,
+    eventId,
+    userId: '',
+    fullName: name,
+    email,
+    company: '',
+    ticketCode,
+    role
+  };
+
+  await storeRegistration(registration);
+
+  let qrDataUrl = '';
+  try {
+    const QRCode = require('qrcode');
+    qrDataUrl = await QRCode.toDataURL(ticketCode, { width: 200, margin: 1 });
+  } catch (qrErr) {
+    context.log(`QR generation failed: ${qrErr.message}`);
+  }
+
+  let emailSent = false;
+  try {
+    context.log(`Sending ticket email to ${registration.email} for event ${eventId}`);
+    await sendTicketEmail(registration, event, qrDataUrl, context);
+    emailSent = true;
+  } catch (emailErr) {
+    context.log(`Ticket email send failed (non-fatal): ${emailErr.message}`);
+  }
+
+  logAudit(
+    'event',
+    eventId,
+    'registration_admin_created',
+    user.userDetails,
+    { email, role, registrationId },
+    context
+  );
+
+  return {
+    id: registrationId,
+    ticketCode,
+    role,
+    fullName: registration.fullName,
+    email: registration.email,
+    emailSent
+  };
+}
 
 /**
- * POST /api/adminRegister
- * Admin-only: register a person with a specific role (bypasses cap for speaker/sponsor/organiser).
+ * POST /api/manualRegister
+ * Admin-only: register one person, or up to 50 speakers in a bulk request.
  */
 module.exports = async function (request, context) {
   context.log('Admin registration request received');
@@ -18,113 +89,144 @@ module.exports = async function (request, context) {
     if (!hasRole(user, 'admin')) return forbidden('Only chapter leads can admin-register');
 
     let body;
-    try { body = await request.json(); } catch {
-      return { status: 400, headers: { 'Content-Type': 'application/json' },
-               body: JSON.stringify({ error: 'Invalid JSON' }) };
+    try {
+      body = await request.json();
+    } catch {
+      return jsonResponse(400, { error: 'Invalid JSON' });
     }
 
-    const { eventId, name, email, role } = body;
-
-    if (!eventId || !name || !email) {
-      return { status: 400, headers: { 'Content-Type': 'application/json' },
-               body: JSON.stringify({ error: 'Missing eventId, name, or email' }) };
-    }
-
-    // Validate email format
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
-      return { status: 400, headers: { 'Content-Type': 'application/json' },
-               body: JSON.stringify({ error: 'Please enter a valid email address' }) };
-    }
-
-    const assignedRole = role || 'attendee';
-    if (!VALID_ROLES.includes(assignedRole)) {
-      return { status: 400, headers: { 'Content-Type': 'application/json' },
-               body: JSON.stringify({ error: `Invalid role. Must be one of: ${VALID_ROLES.join(', ')}` }) };
+    const eventId = typeof body.eventId === 'string' ? body.eventId.trim() : '';
+    if (!eventId) return jsonResponse(400, { error: 'Missing eventId' });
+    const assignedRole = body.role || 'attendee';
+    if (!Array.isArray(body.registrations) && !VALID_ROLES.includes(assignedRole)) {
+      return jsonResponse(400, { error: `Invalid role. Must be one of: ${VALID_ROLES.join(', ')}` });
     }
 
     const event = await getEventById(eventId);
-    if (!event) {
-      return { status: 400, headers: { 'Content-Type': 'application/json' },
-               body: JSON.stringify({ error: 'Event not found' }) };
-    }
+    if (!event) return jsonResponse(400, { error: 'Event not found' });
 
-    // Verify admin has access to this event's chapter
     const chapterSlug = event.chapterSlug || event.partitionKey || '';
     if (!await verifyChapterAccess(user, chapterSlug, context)) {
       return forbidden('You do not have permission to register attendees for this event');
     }
-
     if (event.status === 'completed') {
-      return { status: 400, headers: { 'Content-Type': 'application/json' },
-               body: JSON.stringify({ error: 'Cannot register for a completed event' }) };
+      return jsonResponse(400, { error: 'Cannot register for a completed event' });
     }
 
-    // Check for duplicate by email
-    const existingRegs = await getRegistrationsByEvent(eventId);
-    const alreadyRegistered = existingRegs.find(r => r.email.toLowerCase() === email.trim().toLowerCase());
-    if (alreadyRegistered) {
-      return { status: 409, headers: { 'Content-Type': 'application/json' },
-               body: JSON.stringify({ error: 'This email is already registered for this event' }) };
+    const existingRegistrations = await getRegistrationsByEvent(eventId);
+    const existingEmails = new Set(existingRegistrations.map(registration =>
+      String(registration.email || '').trim().toLowerCase()
+    ));
+
+    if (Array.isArray(body.registrations)) {
+      if (!body.registrations.length) {
+        return jsonResponse(400, { error: 'At least one speaker is required' });
+      }
+      if (body.registrations.length > BULK_LIMIT) {
+        return jsonResponse(400, { error: `A maximum of ${BULK_LIMIT} speakers can be registered at once` });
+      }
+
+      const results = new Array(body.registrations.length);
+      const pending = [];
+      const submittedEmails = new Set();
+
+      body.registrations.forEach((entry, index) => {
+        const person = normalisePerson(entry?.name, entry?.email);
+        const normalisedEmail = person.email.toLowerCase();
+        if (!person.name || !person.email) {
+          results[index] = { row: index + 1, ...person, success: false, error: 'Name and email are required' };
+        } else if (!EMAIL_PATTERN.test(person.email)) {
+          results[index] = { row: index + 1, ...person, success: false, error: 'Enter a valid email address' };
+        } else if (existingEmails.has(normalisedEmail)) {
+          results[index] = { row: index + 1, ...person, success: false, error: 'Already registered for this event' };
+        } else if (submittedEmails.has(normalisedEmail)) {
+          results[index] = { row: index + 1, ...person, success: false, error: 'Duplicate email in this list' };
+        } else {
+          submittedEmails.add(normalisedEmail);
+          pending.push({ index, ...person });
+        }
+      });
+
+      await runInChunks(pending, 5, async person => {
+        try {
+          const registration = await createRegistration(
+            { eventId, name: person.name, email: person.email, role: 'speaker' },
+            event,
+            user,
+            context
+          );
+          results[person.index] = {
+            row: person.index + 1,
+            name: person.name,
+            email: person.email,
+            success: true,
+            emailSent: registration.emailSent
+          };
+        } catch (error) {
+          context.log(`Bulk speaker registration failed for row ${person.index + 1}: ${error.message}`);
+          results[person.index] = {
+            row: person.index + 1,
+            name: person.name,
+            email: person.email,
+            success: false,
+            error: 'Registration could not be saved'
+          };
+        }
+      });
+
+      const registered = results.filter(result => result.success).length;
+      const failed = results.length - registered;
+      logAudit(
+        'event',
+        eventId,
+        'speaker_bulk_registered',
+        user.userDetails,
+        { submitted: results.length, registered, failed },
+        context
+      );
+      return jsonResponse(200, { success: failed === 0, registered, failed, results });
     }
 
-    // Check capacity — speaker/sponsor/organiser bypass
+    const person = normalisePerson(body.name, body.email);
+    if (!person.name || !person.email) {
+      return jsonResponse(400, { error: 'Missing eventId, name, or email' });
+    }
+    if (!EMAIL_PATTERN.test(person.email)) {
+      return jsonResponse(400, { error: 'Please enter a valid email address' });
+    }
+    if (existingEmails.has(person.email.toLowerCase())) {
+      return jsonResponse(409, { error: 'This email is already registered for this event' });
+    }
+
     const capBypassRoles = ['speaker', 'sponsor', 'organiser'];
     const cap = event.registrationCap || 0;
-    if (cap > 0 && existingRegs.length >= cap && !capBypassRoles.includes(assignedRole)) {
-      return { status: 400, headers: { 'Content-Type': 'application/json' },
-               body: JSON.stringify({ error: 'Event is at capacity. Only speaker, sponsor, or organiser roles can bypass the cap.' }) };
+    if (cap > 0 && existingRegistrations.length >= cap && !capBypassRoles.includes(assignedRole)) {
+      return jsonResponse(400, {
+        error: 'Event is at capacity. Only speaker, sponsor, or organiser roles can bypass the cap.'
+      });
     }
 
-    const ticketCode = randomBytes(5).toString('hex').substring(0, 8).toUpperCase();
-    const registrationId = randomUUID();
+    const registration = await createRegistration(
+      { eventId, name: person.name, email: person.email, role: assignedRole },
+      event,
+      user,
+      context
+    );
+    context.log(`Admin registered ${person.email} as ${assignedRole} for event ${eventId} by ${user.userDetails}`);
 
-    const registration = {
-      id: registrationId,
-      eventId,
-      userId: '',
-      fullName: stripHtml(name).trim(),
-      email: stripHtml(email).trim(),
-      company: '',
-      ticketCode,
-      role: assignedRole
-    };
-
-    await storeRegistration(registration);
-
-    // Generate QR and send ticket email
-    let qrDataUrl = '';
-    try {
-      const QRCode = require('qrcode');
-      qrDataUrl = await QRCode.toDataURL(ticketCode, { width: 200, margin: 1 });
-    } catch (qrErr) {
-      context.log(`QR generation failed: ${qrErr.message}`);
-    }
-
-    let emailSent = false;
-    try {
-      context.log(`Sending ticket email to ${registration.email} for event ${eventId}`);
-      await sendTicketEmail(registration, event, qrDataUrl, context);
-      emailSent = true;
-    } catch (emailErr) {
-      context.log(`Ticket email send failed (non-fatal): ${emailErr.message}`);
-    }
-
-    context.log(`Admin registered ${email} as ${assignedRole} for event ${eventId} by ${user.userDetails}`);
-    logAudit('event', eventId, 'registration_admin_created', user.userDetails, { email, role: assignedRole, registrationId }, context);
-
-    return {
-      status: 201,
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        success: true,
-        emailSent,
-        registration: { id: registrationId, ticketCode, role: assignedRole, fullName: registration.fullName, email: registration.email }
-      })
-    };
+    return jsonResponse(201, {
+      success: true,
+      emailSent: registration.emailSent,
+      registration: {
+        id: registration.id,
+        ticketCode: registration.ticketCode,
+        role: registration.role,
+        fullName: registration.fullName,
+        email: registration.email
+      }
+    });
   } catch (error) {
     context.log(`adminRegister error: ${error.message}`);
-    return { status: 500, headers: { 'Content-Type': 'application/json' },
-             body: JSON.stringify({ error: 'Internal server error' }) };
+    return jsonResponse(500, { error: 'Internal server error' });
   }
 };

--- a/api/src/functions/scannerEvents.js
+++ b/api/src/functions/scannerEvents.js
@@ -1,0 +1,55 @@
+const {
+  getAuthUser,
+  getAdminChapterSlugs,
+  hasRole,
+  isSuperAdmin,
+  resolveEmail,
+  unauthorised,
+  forbidden
+} = require('../helpers/auth');
+const { getScannerEventIdsByEmail, listEvents } = require('../helpers/tableStorage');
+
+/**
+ * GET /api/scannerEvents
+ * Lists events the current organiser or volunteer is authorised to scan.
+ */
+module.exports = async function (request, context) {
+  try {
+    const user = getAuthUser(request);
+    if (!user) return unauthorised();
+    if (!hasRole(user, 'admin') && !hasRole(user, 'volunteer')) {
+      return forbidden('Only event organisers and volunteers can access scanner events');
+    }
+
+    const email = await resolveEmail(user);
+    if (!email) return forbidden('Your account email could not be resolved');
+
+    const [allEvents, assignedEventIds, adminChapterSlugs] = await Promise.all([
+      listEvents(),
+      getScannerEventIdsByEmail(email),
+      hasRole(user, 'admin') ? getAdminChapterSlugs(email) : Promise.resolve([])
+    ]);
+    const assignmentSet = new Set(assignedEventIds);
+    const superAdmin = hasRole(user, 'admin') && isSuperAdmin(email);
+
+    const events = allEvents
+      .filter(event => event.status !== 'completed')
+      .filter(event => {
+        const chapterSlug = String(event.chapterSlug || event.partitionKey || '').toLowerCase();
+        return superAdmin || assignmentSet.has(event.rowKey) || adminChapterSlugs.includes(chapterSlug);
+      })
+      .map(event => ({
+        id: event.rowKey,
+        title: event.title,
+        date: event.date || '',
+        location: event.location || '',
+        chapterSlug: event.chapterSlug || event.partitionKey || ''
+      }))
+      .sort((a, b) => String(a.date).localeCompare(String(b.date)) || a.title.localeCompare(b.title));
+
+    return { status: 200, jsonBody: { events } };
+  } catch (error) {
+    context.log(`scannerEvents error: ${error.message}`);
+    return { status: 500, jsonBody: { error: 'Internal server error' } };
+  }
+};

--- a/api/src/functions/updateChapter.js
+++ b/api/src/functions/updateChapter.js
@@ -80,8 +80,8 @@ module.exports = async function (request, context) {
       updatedAt: new Date().toISOString()
     }, 'Merge');
 
-    // Regenerate the chapter markdown page via GitHub Contents API
-    let pageUpdated = false;
+    // Queue an automated PR because main is protected from direct writes.
+    let pageUpdateQueued = false;
     try {
       const appId = process.env.GITHUB_APP_ID;
       const privateKey = (process.env.GITHUB_APP_PRIVATE_KEY || '').replace(/\\n/g, '\n');
@@ -96,17 +96,12 @@ module.exports = async function (request, context) {
         });
 
         const filePath = `src/chapters/${chapterSlug}/index.md`;
-
-        // Get current file SHA and existing coordinates (needed for update)
-        let sha = '';
         let existingLatitude = '';
         let existingLongitude = '';
         try {
           const { data } = await octokit.repos.getContent({
             owner: repoOwner, repo: repoName, path: filePath, ref: 'main'
           });
-          sha = data.sha;
-          // Extract existing coordinates from the file so they are preserved
           const fileContent = Buffer.from(data.content, 'base64').toString('utf8');
           const latMatch = fileContent.match(/^latitude:\s*(-?[\d.]+)/m);
           const lngMatch = fileContent.match(/^longitude:\s*(-?[\d.]+)/m);
@@ -127,27 +122,29 @@ module.exports = async function (request, context) {
           longitude: existingLongitude
         });
 
-        const params = {
+        await octokit.repos.createDispatchEvent({
           owner: repoOwner,
           repo: repoName,
-          path: filePath,
-          message: `Update chapter page for ${application.city}\n\nUpdated by ${user.userDetails} via dashboard.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`,
-          content: Buffer.from(markdown).toString('base64'),
-          branch: 'main'
-        };
-        if (sha) params.sha = sha;
-
-        await octokit.repos.createOrUpdateFileContents(params);
-        pageUpdated = true;
-        context.log(`Chapter page updated for ${chapterSlug}`);
+          event_type: 'chapter-updated',
+          client_payload: {
+            chapter_slug: chapterSlug,
+            chapter_city: application.city,
+            chapter_markdown_base64: Buffer.from(markdown).toString('base64')
+          }
+        });
+        pageUpdateQueued = true;
+        context.log(`Chapter page update queued for ${chapterSlug}`);
       } else {
-        context.log('GitHub App configuration missing — page update skipped');
+        context.log('GitHub App configuration missing — page update PR skipped');
       }
     } catch (err) {
-      context.log(`GitHub page update failed: ${err.message}`);
+      context.log(`GitHub page update dispatch failed: ${err.message}`);
     }
 
-    logAudit('chapter', chapterSlug, 'chapter_updated', user.userDetails, { leadCount: sanitisedLeads.length, pageUpdated }, context);
+    logAudit('chapter', chapterSlug, 'chapter_updated', user.userDetails, {
+      leadCount: sanitisedLeads.length,
+      pageUpdateQueued
+    }, context);
 
     return {
       status: 200,
@@ -155,7 +152,8 @@ module.exports = async function (request, context) {
       body: JSON.stringify({
         success: true,
         leads: sanitisedLeads.map(l => ({ name: l.name, email: l.email })),
-        pageUpdated
+        pageUpdated: pageUpdateQueued,
+        pageUpdateQueued
       })
     };
   } catch (error) {

--- a/api/src/helpers/tableStorage.js
+++ b/api/src/helpers/tableStorage.js
@@ -553,7 +553,65 @@ async function isVolunteerOrOrganiserByRegistration(email, eventId) {
   return null;
 }
 
+async function getScannerEventIdsByEmail(email) {
+  const normalised = email.trim().toLowerCase();
+  const eventIds = new Set();
+  const registrationClient = getTableClient('EventRegistrations');
+
+  const registrations = registrationClient.listEntities({
+    queryOptions: { filter: `normalisedEmail eq '${normalised.replace(/'/g, "''")}'` }
+  });
+  for await (const entity of registrations) {
+    if (entity.role === 'volunteer' || entity.role === 'organiser') {
+      eventIds.add(entity.partitionKey);
+    }
+  }
+
+  // Existing registrations predate normalisedEmail, so compare role records in code.
+  const legacyRegistrations = registrationClient.listEntities({
+    queryOptions: {
+      filter: "(role eq 'volunteer' or role eq 'organiser')",
+      select: ['PartitionKey', 'email', 'role']
+    }
+  });
+  for await (const entity of legacyRegistrations) {
+    if (String(entity.email || '').trim().toLowerCase() === normalised) {
+      eventIds.add(entity.partitionKey);
+    }
+  }
+
+  const volunteerClient = getTableClient('EventVolunteers');
+  const volunteers = volunteerClient.listEntities({
+    queryOptions: { filter: `email eq '${normalised.replace(/'/g, "''")}'`, select: ['PartitionKey'] }
+  });
+  for await (const entity of volunteers) {
+    eventIds.add(entity.partitionKey);
+  }
+
+  return [...eventIds].filter(Boolean);
+}
+
 // ─── Chapter Leads (for role assignment) ───
+
+function applicationHasLeadEmail(application, normalisedEmail) {
+  if (application.leadsJson) {
+    try {
+      const leads = JSON.parse(application.leadsJson);
+      if (Array.isArray(leads)) {
+        return leads.some(lead =>
+          String(lead?.email || '').trim().toLowerCase() === normalisedEmail
+        );
+      }
+    } catch {
+      // Fall back to original application fields if stored JSON is malformed.
+    }
+  }
+
+  return (
+    String(application.email || '').trim().toLowerCase() === normalisedEmail ||
+    String(application.secondLeadEmail || '').trim().toLowerCase() === normalisedEmail
+  );
+}
 
 async function getApprovedApplicationByEmail(email) {
   const client = getTableClient('ChapterApplications');
@@ -562,8 +620,7 @@ async function getApprovedApplicationByEmail(email) {
     queryOptions: { filter: `status eq 'approved'` }
   });
   for await (const entity of entities) {
-    if (entity.email && entity.email.toLowerCase() === normalised) return entity;
-    if (entity.secondLeadEmail && entity.secondLeadEmail.toLowerCase() === normalised) return entity;
+    if (applicationHasLeadEmail(entity, normalised)) return entity;
   }
   return null;
 }
@@ -580,8 +637,7 @@ async function getApprovedApplicationsByEmail(email) {
   });
   const results = [];
   for await (const entity of entities) {
-    if ((entity.email && entity.email.toLowerCase() === normalised) ||
-        (entity.secondLeadEmail && entity.secondLeadEmail.toLowerCase() === normalised)) {
+    if (applicationHasLeadEmail(entity, normalised)) {
       results.push(entity);
     }
   }
@@ -811,7 +867,7 @@ module.exports = {
   getPostEventJob, upsertPostEventJob, createPostEventJob, updatePostEventJob,
   getPostEventDeliveries, upsertPostEventDelivery, createPostEventDelivery, updatePostEventDelivery,
   storeVolunteer, getVolunteersByEvent, removeVolunteer, isVolunteerForAnyEvent,
-  getRegistrationsByRole, isVolunteerOrOrganiserByRegistration, VALID_ROLES,
+  getRegistrationsByRole, isVolunteerOrOrganiserByRegistration, getScannerEventIdsByEmail, VALID_ROLES,
   getApprovedApplicationByEmail, getApprovedApplicationsByEmail,
   storeSessionizeCache, getSessionizeCache,
   storeSubscription, removeSubscription, getSubscriptionsByChapter, isSubscribed,

--- a/api/tests/functions-coverage.test.js
+++ b/api/tests/functions-coverage.test.js
@@ -40,6 +40,7 @@ jest.mock('../src/helpers/tableStorage', () => ({
   getBadgesByEvent: jest.fn().mockResolvedValue([]),
   getRegistrationsByRole: jest.fn().mockResolvedValue([]),
   isVolunteerOrOrganiserByRegistration: jest.fn().mockResolvedValue(null),
+  getScannerEventIdsByEmail: jest.fn().mockResolvedValue([]),
   isVolunteerForAnyEvent: jest.fn().mockResolvedValue(null),
   VALID_ROLES: ['attendee', 'volunteer', 'speaker', 'sponsor', 'organiser'],
   getApprovedApplicationByEmail: jest.fn(),

--- a/api/tests/functions.test.js
+++ b/api/tests/functions.test.js
@@ -26,6 +26,7 @@ jest.mock('../src/helpers/tableStorage', () => ({
   getBadgesByEvent: jest.fn().mockResolvedValue([]),
   getRegistrationsByRole: jest.fn().mockResolvedValue([]),
   isVolunteerOrOrganiserByRegistration: jest.fn().mockResolvedValue(null),
+  getScannerEventIdsByEmail: jest.fn().mockResolvedValue([]),
   isVolunteerForAnyEvent: jest.fn().mockResolvedValue(null),
   VALID_ROLES: ['attendee', 'volunteer', 'speaker', 'sponsor', 'organiser'],
   getApprovedApplicationByEmail: jest.fn(),
@@ -519,6 +520,93 @@ describe('adminRegister function', () => {
     const res = await adminRegister(req, context);
     expect(res.status).toBe(201);
     expect(JSON.parse(res.body).registration.role).toBe('attendee');
+  });
+
+  test('bulk registers valid speakers and reports duplicate rows', async () => {
+    storage.getEventById.mockResolvedValueOnce({
+      rowKey: 'ev-1',
+      partitionKey: 'perth',
+      title: 'Test',
+      status: 'published',
+      registrationCap: 1
+    });
+    storage.getRegistrationsByEvent.mockResolvedValueOnce([{ rowKey: 'r1', email: 'existing@test.com' }]);
+    const req = makeAuthRequest('POST', {
+      eventId: 'ev-1',
+      registrations: [
+        { name: 'Speaker One', email: 'one@test.com' },
+        { name: 'Existing', email: 'existing@test.com' },
+        { name: 'Speaker Duplicate', email: 'one@test.com' }
+      ]
+    }, ['admin']);
+
+    const res = await adminRegister(req, context);
+    const body = JSON.parse(res.body);
+
+    expect(res.status).toBe(200);
+    expect(body.registered).toBe(1);
+    expect(body.failed).toBe(2);
+    expect(body.results[0]).toEqual(expect.objectContaining({ success: true, email: 'one@test.com' }));
+    expect(body.results[1].error).toMatch(/already registered/i);
+    expect(body.results[2].error).toMatch(/duplicate/i);
+    expect(storage.storeRegistration).toHaveBeenCalledTimes(1);
+    expect(storage.storeRegistration).toHaveBeenCalledWith(expect.objectContaining({ role: 'speaker' }));
+  });
+
+  test('rejects bulk speaker requests above the limit', async () => {
+    storage.getEventById.mockResolvedValueOnce({
+      rowKey: 'ev-1',
+      partitionKey: 'perth',
+      title: 'Test',
+      status: 'published'
+    });
+    const registrations = Array.from({ length: 51 }, (_, index) => ({
+      name: `Speaker ${index}`,
+      email: `speaker${index}@test.com`
+    }));
+    const req = makeAuthRequest('POST', { eventId: 'ev-1', registrations }, ['admin']);
+
+    const res = await adminRegister(req, context);
+
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/maximum of 50/i);
+    expect(storage.storeRegistration).not.toHaveBeenCalled();
+  });
+});
+
+describe('scannerEvents function', () => {
+  const scannerEvents = require('../src/functions/scannerEvents');
+
+  beforeEach(() => jest.clearAllMocks());
+
+  test('lists assigned events for a volunteer and excludes completed events', async () => {
+    storage.getScannerEventIdsByEmail.mockResolvedValueOnce(['ev-1', 'ev-2']);
+    storage.listEvents.mockResolvedValueOnce([
+      { rowKey: 'ev-1', partitionKey: 'perth', title: 'Active Event', date: '2026-09-01', status: 'published' },
+      { rowKey: 'ev-2', partitionKey: 'perth', title: 'Past Event', date: '2026-01-01', status: 'completed' },
+      { rowKey: 'ev-3', partitionKey: 'sydney', title: 'Other Event', date: '2026-10-01', status: 'published' }
+    ]);
+    const req = makeAuthRequest('GET', null, ['volunteer']);
+
+    const res = await scannerEvents(req, context);
+
+    expect(res.status).toBe(200);
+    expect(res.jsonBody.events).toEqual([
+      expect.objectContaining({ id: 'ev-1', title: 'Active Event' })
+    ]);
+  });
+
+  test('lists chapter events for an organiser', async () => {
+    storage.listEvents.mockResolvedValueOnce([
+      { rowKey: 'ev-1', partitionKey: 'perth', title: 'Perth Event', date: '2026-09-01', status: 'published' },
+      { rowKey: 'ev-2', partitionKey: 'sydney', title: 'Sydney Event', date: '2026-10-01', status: 'published' }
+    ]);
+    const req = makeAuthRequest('GET', null, ['admin']);
+
+    const res = await scannerEvents(req, context);
+
+    expect(res.status).toBe(200);
+    expect(res.jsonBody.events.map(event => event.id)).toEqual(['ev-1']);
   });
 });
 

--- a/api/tests/octokit-integration.test.js
+++ b/api/tests/octokit-integration.test.js
@@ -9,7 +9,12 @@ process.env.DISCORD_NOTIFICATIONS_CHANNEL_ID = 'test-notif-channel';
 
 // Track Octokit mock calls
 const mockCreateDispatchEvent = jest.fn().mockResolvedValue({});
-const mockGetContent = jest.fn().mockResolvedValue({ data: { sha: 'abc123' } });
+const mockGetContent = jest.fn().mockResolvedValue({
+  data: {
+    sha: 'abc123',
+    content: Buffer.from('latitude: -31.95\nlongitude: 115.86\n').toString('base64')
+  }
+});
 const mockCreateOrUpdateFileContents = jest.fn().mockResolvedValue({});
 const mockOctokitConstructor = jest.fn().mockImplementation(() => ({
   repos: {
@@ -407,7 +412,7 @@ describe('createEvent — GitHub dispatch integration', () => {
 
 // ─── updateChapter — Octokit integration ───────────────────────────
 
-describe('updateChapter — GitHub Contents API integration', () => {
+describe('updateChapter — automated PR dispatch integration', () => {
   const updateChapter = require('../src/functions/updateChapter');
 
   const validLeads = {
@@ -453,41 +458,44 @@ describe('updateChapter — GitHub Contents API integration', () => {
     });
   });
 
-  test('passes SHA to createOrUpdateFileContents when file exists', async () => {
+  test('dispatches a chapter update with generated markdown', async () => {
     setGitHubEnv();
-    mockGetContent.mockResolvedValueOnce({ data: { sha: 'existing-sha-456' } });
     await updateChapter(makeAuthRequest('POST', validLeads, ['admin']), context);
 
-    expect(mockCreateOrUpdateFileContents).toHaveBeenCalledWith(
+    expect(mockCreateDispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         owner: 'Global-Security-Community',
         repo: 'core-website',
-        path: 'src/chapters/perth/index.md',
-        branch: 'main',
-        sha: 'existing-sha-456',
-        content: expect.any(String),
-        message: expect.stringContaining('Update chapter page for Perth')
+        event_type: 'chapter-updated',
+        client_payload: expect.objectContaining({
+          chapter_slug: 'perth',
+          chapter_city: 'Perth',
+          chapter_markdown_base64: expect.any(String)
+        })
       })
     );
   });
 
-  test('omits SHA when getContent fails (new file)', async () => {
+  test('still dispatches when the existing page cannot be read', async () => {
     setGitHubEnv();
     mockGetContent.mockRejectedValueOnce(new Error('Not found'));
     await updateChapter(makeAuthRequest('POST', validLeads, ['admin']), context);
 
-    const callArgs = mockCreateOrUpdateFileContents.mock.calls[0][0];
-    expect(callArgs.sha).toBeUndefined();
+    expect(mockCreateDispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ event_type: 'chapter-updated' })
+    );
   });
 
   test('encodes markdown content as base64', async () => {
     setGitHubEnv();
     await updateChapter(makeAuthRequest('POST', validLeads, ['admin']), context);
 
-    const callArgs = mockCreateOrUpdateFileContents.mock.calls[0][0];
-    const decoded = Buffer.from(callArgs.content, 'base64').toString('utf-8');
+    const payload = mockCreateDispatchEvent.mock.calls[0][0].client_payload;
+    const decoded = Buffer.from(payload.chapter_markdown_base64, 'base64').toString('utf-8');
     expect(decoded).toContain('Perth');
     expect(decoded).toContain('layout:');
+    expect(decoded).toContain('latitude: -31.95');
+    expect(decoded).not.toContain('alice@test.com');
   });
 
   test('skips GitHub update when env vars are missing', async () => {
@@ -498,23 +506,24 @@ describe('updateChapter — GitHub Contents API integration', () => {
     expect(mockGetContent).not.toHaveBeenCalled();
   });
 
-  test('continues on createOrUpdateFileContents failure', async () => {
+  test('continues when the update workflow cannot be dispatched', async () => {
     setGitHubEnv();
-    mockCreateOrUpdateFileContents.mockRejectedValueOnce(new Error('Conflict'));
+    mockCreateDispatchEvent.mockRejectedValueOnce(new Error('Dispatch failed'));
     const res = await updateChapter(makeAuthRequest('POST', validLeads, ['admin']), context);
 
     expect(res.status).toBe(200);
     const body = JSON.parse(res.body);
     expect(body.pageUpdated).toBe(false);
+    expect(body.pageUpdateQueued).toBe(false);
   });
 
-  test('commit message includes city name and co-author', async () => {
+  test('reports that the automated page update was queued', async () => {
     setGitHubEnv();
-    await updateChapter(makeAuthRequest('POST', validLeads, ['admin']), context);
+    const res = await updateChapter(makeAuthRequest('POST', validLeads, ['admin']), context);
 
-    const callArgs = mockCreateOrUpdateFileContents.mock.calls[0][0];
-    expect(callArgs.message).toContain('Perth');
-    expect(callArgs.message).toContain('Co-authored-by: Copilot');
+    const body = JSON.parse(res.body);
+    expect(body.pageUpdated).toBe(true);
+    expect(body.pageUpdateQueued).toBe(true);
   });
 });
 

--- a/api/tests/tableStorageVolunteer.test.js
+++ b/api/tests/tableStorageVolunteer.test.js
@@ -14,7 +14,10 @@ jest.mock('@azure/data-tables', () => ({
 
 const {
   storeRegistration,
-  isVolunteerOrOrganiserByRegistration
+  isVolunteerOrOrganiserByRegistration,
+  getScannerEventIdsByEmail,
+  getApprovedApplicationByEmail,
+  getApprovedApplicationsByEmail
 } = require('../src/helpers/tableStorage');
 
 function entities(values) {
@@ -81,5 +84,80 @@ describe('volunteer registration email matching', () => {
         select: ['email', 'role']
       }
     });
+  });
+
+  test('combines current, legacy, and volunteer-table scanner assignments', async () => {
+    mockClient.listEntities
+      .mockReturnValueOnce(entities([
+        { partitionKey: 'event-1', role: 'volunteer' },
+        { partitionKey: 'ignored-event', role: 'attendee' }
+      ]))
+      .mockReturnValueOnce(entities([
+        { partitionKey: 'event-2', email: 'Volunteer@Example.com', role: 'organiser' }
+      ]))
+      .mockReturnValueOnce(entities([
+        { partitionKey: 'event-3' },
+        { partitionKey: 'event-1' }
+      ]));
+
+    const eventIds = await getScannerEventIdsByEmail('volunteer@example.com');
+
+    expect(eventIds).toEqual(['event-1', 'event-2', 'event-3']);
+  });
+
+  test('matches a chapter lead added through leadsJson', async () => {
+    mockClient.listEntities.mockReturnValueOnce(entities([{
+      partitionKey: 'applications',
+      rowKey: 'melbourne',
+      city: 'Melbourne',
+      status: 'approved',
+      email: 'original@example.com',
+      leadsJson: JSON.stringify([
+        { name: 'Original Lead', email: 'original@example.com' },
+        { name: 'New Lead', email: 'New.Lead@Example.com' }
+      ])
+    }]));
+
+    const application = await getApprovedApplicationByEmail('new.lead@example.com');
+
+    expect(application).toEqual(expect.objectContaining({ city: 'Melbourne' }));
+  });
+
+  test('includes all chapters where the user appears in leadsJson', async () => {
+    mockClient.listEntities.mockReturnValueOnce(entities([
+      {
+        city: 'Melbourne',
+        status: 'approved',
+        leadsJson: JSON.stringify([{ email: 'lead@example.com' }])
+      },
+      {
+        city: 'Sydney',
+        status: 'approved',
+        leadsJson: JSON.stringify([{ email: 'other@example.com' }])
+      },
+      {
+        city: 'Perth',
+        status: 'approved',
+        secondLeadEmail: 'LEAD@example.com'
+      }
+    ]));
+
+    const applications = await getApprovedApplicationsByEmail('lead@example.com');
+
+    expect(applications.map(application => application.city)).toEqual(['Melbourne', 'Perth']);
+  });
+
+  test('does not retain legacy access after an edited lead is removed', async () => {
+    mockClient.listEntities.mockReturnValueOnce(entities([{
+      city: 'Melbourne',
+      status: 'approved',
+      email: 'removed@example.com',
+      secondLeadEmail: 'also-removed@example.com',
+      leadsJson: JSON.stringify([{ email: 'current@example.com' }])
+    }]));
+
+    const application = await getApprovedApplicationByEmail('removed@example.com');
+
+    expect(application).toBeNull();
   });
 });

--- a/src/chapters/melbourne/index.md
+++ b/src/chapters/melbourne/index.md
@@ -12,4 +12,8 @@ leads:
   - name: "Santhoshkumar Anandakrishnan"
     email_hash: "df465f66c4662a33ec4e7a5b0fa90e1f"
     linkedin: "https://www.linkedin.com/in/santhoshkumar-anandakrishnan/"
+    website: "https://skylinetechnology.org/blog/"
+  - name: "Pouya"
+    email_hash: "de71bed2eb24de2c38d45c6c37aa3c95"
+    linkedin: "https://www.linkedin.com/in/koushandehfar/"
 ---

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2169,6 +2169,53 @@ button:focus-visible {
   min-width: 120px;
 }
 
+.bulk-speaker-panel {
+  max-width: 760px;
+  margin: 0 0 var(--space-2xl);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
+.bulk-speaker-panel summary {
+  padding: var(--space-lg);
+  color: var(--color-primary-navy);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.bulk-speaker-panel summary:hover {
+  color: var(--color-primary-teal);
+}
+
+.bulk-speaker-panel__content {
+  padding: 0 var(--space-lg) var(--space-lg);
+}
+
+.bulk-speaker-panel__content .form-group {
+  max-width: none;
+}
+
+.bulk-speaker-results {
+  margin-top: var(--space-lg);
+}
+
+.bulk-speaker-results__table {
+  overflow-x: auto;
+}
+
+.bulk-result {
+  font-weight: 600;
+}
+
+.bulk-result--success {
+  color: var(--color-text-success);
+}
+
+.bulk-result--error {
+  color: var(--color-text-danger);
+}
+
 /* Dashboard detail panel — 4-column grid */
 .detail-panel {
   display: grid;
@@ -2234,11 +2281,16 @@ button:focus-visible {
 
 /* Scanner page */
 .scanner-setup {
-  max-width: 400px;
+  max-width: 640px;
 }
 
 .btn-start-scanner {
   margin-top: var(--space-sm);
+}
+
+.scanner-setup button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 .scan-result {

--- a/src/dashboard/index.md
+++ b/src/dashboard/index.md
@@ -156,6 +156,20 @@ title: Dashboard
       </select>
       <button id="admin-reg-btn" type="button">Register</button>
     </div>
+    <details class="bulk-speaker-panel">
+      <summary>Bulk register speakers</summary>
+      <div class="bulk-speaker-panel__content">
+        <p class="text-muted">Paste speaker names and email addresses from a spreadsheet or CSV. Use one speaker per line in <strong>Name, email</strong> format.</p>
+        <div class="form-group">
+          <label for="bulk-speaker-input">Speakers</label>
+          <textarea id="bulk-speaker-input" rows="7" placeholder="Alex Smith, alex@example.com&#10;Jordan Lee, jordan@example.com"></textarea>
+          <p class="char-hint">Up to 50 speakers. A header row is optional.</p>
+        </div>
+        <button id="bulk-speaker-btn" type="button">Register Speakers</button>
+        <div id="bulk-speaker-status" class="form-message is-hidden" role="status" aria-live="polite"></div>
+        <div id="bulk-speaker-results" class="bulk-speaker-results"></div>
+      </div>
+    </details>
     <h3>Attendees</h3>
     <div id="role-action-bar" class="role-action-bar is-hidden">
       <span id="role-selected-count">0 selected</span>

--- a/src/js/dashboard.js
+++ b/src/js/dashboard.js
@@ -561,7 +561,8 @@
 
         // Load attendees with role support
         var adminRegBtn = document.getElementById('admin-reg-btn');
-        adminRegBtn.addEventListener('click', function() { adminRegister(eventId); });
+        adminRegBtn.onclick = function() { adminRegister(eventId); };
+        document.getElementById('bulk-speaker-btn').onclick = function() { bulkRegisterSpeakers(eventId); };
 
         if (!data.attendees || data.attendees.length === 0) {
           document.getElementById('detail-attendees').innerHTML = '<p>No registrations yet.</p>';
@@ -1575,6 +1576,7 @@
       'event_deleted': 'Deleted event',
       'status_changed': 'Changed status',
       'registration_admin_created': 'Admin registered attendee',
+      'speaker_bulk_registered': 'Bulk registered speakers',
       'registration_role_updated': 'Updated roles',
       'attendee_checked_in': 'Checked in attendee',
       'partner_added': 'Added partner',
@@ -1591,6 +1593,7 @@
   function formatAuditDetails(action, d) {
     if (action === 'status_changed') return GSC.esc(d.from || '?') + ' → ' + GSC.esc(d.to || '?');
     if (action === 'registration_admin_created') return GSC.esc(d.email || '') + ' as ' + GSC.esc(d.role || 'attendee');
+    if (action === 'speaker_bulk_registered') return GSC.esc((d.registered || 0) + '') + ' registered' + (d.failed ? ', ' + d.failed + ' failed' : '');
     if (action === 'registration_role_updated') return GSC.esc((d.count || 0) + '') + ' attendee(s) → ' + GSC.esc(d.role || '');
     if (action === 'attendee_checked_in') return GSC.esc(d.attendee || '');
     if (action === 'email_resent') return GSC.esc((d.sent || 0) + '') + ' sent' + (d.failed ? ', ' + d.failed + ' failed' : '');
@@ -1624,6 +1627,108 @@
       }
     })
     .catch(function() { alert('Network error.'); });
+  }
+
+  function parseSpeakerRows(value) {
+    return value.split(/\r?\n/).map(function(line, index) {
+      var trimmed = line.trim();
+      if (!trimmed) return null;
+      var separator = trimmed.indexOf('\t') !== -1 ? '\t' : ',';
+      var separatorIndex = trimmed.lastIndexOf(separator);
+      if (separatorIndex === -1) {
+        return { row: index + 1, error: 'Use Name, email format.' };
+      }
+      var name = trimmed.slice(0, separatorIndex).trim().replace(/^"|"$/g, '');
+      var email = trimmed.slice(separatorIndex + 1).trim().replace(/^"|"$/g, '');
+      if (index === 0 && /^(name|speaker)$/i.test(name) && /^email/i.test(email)) return null;
+      if (!name || !email) return { row: index + 1, name: name, email: email, error: 'Name and email are required.' };
+      return { row: index + 1, name: name, email: email };
+    }).filter(Boolean);
+  }
+
+  function bulkRegisterSpeakers(eventId) {
+    var input = document.getElementById('bulk-speaker-input');
+    var button = document.getElementById('bulk-speaker-btn');
+    var status = document.getElementById('bulk-speaker-status');
+    var resultsEl = document.getElementById('bulk-speaker-results');
+    var rows = parseSpeakerRows(input.value);
+    var invalidRows = rows.filter(function(row) { return row.error; });
+
+    status.className = 'form-message';
+    resultsEl.innerHTML = '';
+    if (!rows.length) {
+      status.classList.add('form-message--error');
+      status.textContent = 'Paste at least one speaker name and email address.';
+      return;
+    }
+    if (rows.length > 50) {
+      status.classList.add('form-message--error');
+      status.textContent = 'You can register up to 50 speakers at a time.';
+      return;
+    }
+    if (invalidRows.length) {
+      status.classList.add('form-message--error');
+      status.textContent = 'Fix the formatting on row' + (invalidRows.length === 1 ? ' ' : 's ') +
+        invalidRows.map(function(row) { return row.row; }).join(', ') + '.';
+      renderBulkSpeakerResults(rows.map(function(row) {
+        return { row: row.row, name: row.name || '', email: row.email || '', success: !row.error, error: row.error || 'Ready' };
+      }));
+      return;
+    }
+
+    button.disabled = true;
+    button.textContent = 'Registering...';
+    status.classList.add('form-message--warning');
+    status.textContent = 'Registering ' + rows.length + ' speaker' + (rows.length === 1 ? '' : 's') + ' and sending tickets...';
+
+    GSC.fetch('/api/manualRegister', {
+      method: 'POST',
+      headers: {'Content-Type':'application/json'},
+      body: JSON.stringify({
+        eventId: eventId,
+        registrations: rows.map(function(row) { return { name: row.name, email: row.email, role: 'speaker' }; })
+      })
+    })
+    .then(function(response) {
+      return response.json().then(function(data) {
+        if (!response.ok) throw new Error(data.error || 'Bulk registration failed.');
+        return data;
+      });
+    })
+    .then(function(data) {
+      button.disabled = false;
+      button.textContent = 'Register Speakers';
+      status.className = 'form-message ' + (data.failed ? 'form-message--warning' : 'form-message--success');
+      status.textContent = data.registered + ' registered' + (data.failed ? ', ' + data.failed + ' need attention.' : '.');
+      renderBulkSpeakerResults(data.results || []);
+      if (!data.failed) input.value = '';
+      if (data.registered) {
+        viewEvent(eventId, currentChapterSlug, document.getElementById('detail-title').textContent);
+      }
+    })
+    .catch(function(error) {
+      button.disabled = false;
+      button.textContent = 'Register Speakers';
+      status.className = 'form-message form-message--error';
+      status.textContent = error.message || 'Unable to register speakers. Try again.';
+    });
+  }
+
+  function renderBulkSpeakerResults(results) {
+    var resultsEl = document.getElementById('bulk-speaker-results');
+    if (!results.length) {
+      resultsEl.innerHTML = '';
+      return;
+    }
+    var html = '<div class="bulk-speaker-results__table"><table><thead><tr><th>Speaker</th><th>Email</th><th>Result</th></tr></thead><tbody>';
+    results.forEach(function(result) {
+      html += '<tr><td>' + GSC.esc(result.name || '') + '</td><td>' + GSC.esc(result.email || '') + '</td><td>' +
+        (result.success
+          ? '<span class="bulk-result bulk-result--success">Registered</span>'
+          : '<span class="bulk-result bulk-result--error">' + GSC.esc(result.error || 'Failed') + '</span>') +
+        '</td></tr>';
+    });
+    resultsEl.innerHTML = html + '</tbody></table></div>';
   }
 
   // ─── Edit Event ───
@@ -1918,7 +2023,7 @@
       if (d.success) {
         msg.style.display = 'block';
         msg.style.backgroundColor = '#d4edda'; msg.style.color = '#155724';
-        msg.textContent = 'Chapter updated.' + (d.pageUpdated ? ' Page will redeploy shortly.' : ' Page could not be updated automatically.');
+        msg.textContent = 'Chapter updated.' + (d.pageUpdateQueued ? ' Page update queued for automated checks.' : ' Page update could not be queued automatically.');
       } else {
         msg.style.display = 'block';
         msg.style.backgroundColor = '#f8d7da'; msg.style.color = '#721c24';

--- a/src/js/scanner.js
+++ b/src/js/scanner.js
@@ -4,12 +4,57 @@
   var totalCheckedIn = 0;
   var totalRegistered = 0;
   var scanner = null;
+  var eventSelect = document.getElementById('scanner-event-id');
+  var startButton = document.getElementById('start-scanner-btn');
+  var eventHelp = document.getElementById('scanner-event-help');
 
-  document.getElementById('start-scanner-btn').addEventListener('click', function() {
-    eventId = document.getElementById('scanner-event-id').value.trim();
-    if (!eventId) { alert('Please enter an event ID.'); return; }
+  loadScannerEvents();
+
+  function loadScannerEvents() {
+    GSC.fetch('/api/scannerEvents')
+      .then(function(response) {
+        return response.json().then(function(data) {
+          if (!response.ok) throw new Error(data.error || 'Unable to load scanner events.');
+          return data;
+        });
+      })
+      .then(function(data) {
+        var events = data.events || [];
+        if (!events.length) {
+          eventSelect.innerHTML = '<option value="">No assigned events</option>';
+          eventHelp.textContent = 'You are not currently assigned to any active events.';
+          return;
+        }
+
+        var options = '<option value="">Choose an event</option>';
+        events.forEach(function(event) {
+          var details = [event.date, event.location].filter(Boolean).join(' - ');
+          var label = event.title + (details ? ' - ' + details : '');
+          options += '<option value="' + GSC.esc(event.id) + '">' + GSC.esc(label) + '</option>';
+        });
+        eventSelect.innerHTML = options;
+        eventSelect.disabled = false;
+        startButton.disabled = false;
+        eventHelp.textContent = events.length === 1
+          ? 'One event is available for check-in.'
+          : events.length + ' events are available for check-in.';
+      })
+      .catch(function(error) {
+        eventSelect.innerHTML = '<option value="">Events unavailable</option>';
+        eventHelp.textContent = error.message || 'Unable to load scanner events. Refresh the page to try again.';
+      });
+  }
+
+  startButton.addEventListener('click', function() {
+    eventId = eventSelect.value;
+    if (!eventId) {
+      eventHelp.textContent = 'Choose an event before starting the scanner.';
+      eventSelect.focus();
+      return;
+    }
 
     document.getElementById('scanner-wrap').style.display = 'block';
+    eventSelect.disabled = true;
     this.disabled = true;
     this.textContent = 'Scanner Active';
 

--- a/src/scanner/index.md
+++ b/src/scanner/index.md
@@ -7,9 +7,12 @@ title: Check-in Scanner
   <h1>Check-in Scanner</h1>
 
   <div class="form-group scanner-setup">
-    <label for="scanner-event-id">Event ID *</label>
-    <input type="text" id="scanner-event-id" placeholder="Paste the event ID from your dashboard">
-    <button id="start-scanner-btn" type="button" class="btn-start-scanner">Start Scanner</button>
+    <label for="scanner-event-id">Event</label>
+    <select id="scanner-event-id" disabled>
+      <option value="">Loading your events...</option>
+    </select>
+    <p id="scanner-event-help" class="char-hint" role="status" aria-live="polite">Finding events you can check in.</p>
+    <button id="start-scanner-btn" type="button" class="btn-start-scanner" disabled>Start Scanner</button>
   </div>
 
   <div id="scanner-wrap" class="is-hidden">

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -84,6 +84,11 @@
       "headers": { "Cache-Control": "private, no-store" }
     },
     {
+      "route": "/api/scannerEvents",
+      "allowedRoles": ["admin", "volunteer"],
+      "headers": { "Cache-Control": "private, no-store" }
+    },
+    {
       "route": "/api/issueBadges",
       "allowedRoles": ["admin"],
       "headers": { "Cache-Control": "private, no-store" }


### PR DESCRIPTION
## Why

Event teams currently need manually shared event IDs to use the scanner, while organisers must register speakers one at a time. Chapter lead edits also saved to storage but failed to update the protected `main` branch, and edited lead lists were not used for admin role assignment.

## What changed

- Populate the scanner with active events the signed-in volunteer or organiser is authorised to manage.
- Add paste-friendly bulk speaker registration with validation, bounded concurrency, ticket delivery, and row-level results.
- Dispatch chapter page edits to an automated workflow that creates a PR, runs required checks, enables squash auto-merge, and serializes updates per chapter.
- Treat edited `leadsJson` data as authoritative for granting and revoking chapter admin access.
- Reconcile Melbourne's previously persisted second lead into the generated chapter page.

## Notes

Chapter page updates remain asynchronous because protected-branch checks must pass before merge. Manual intervention is only required when CI fails or GitHub cannot merge the generated PR.

Closes #201
Closes #140