### PR TITLE
Preserve Discord IDs during chapter updates

### DIFF
--- a/api/src/functions/updateChapter.js
+++ b/api/src/functions/updateChapter.js
@@ -98,6 +98,8 @@ module.exports = async function (request, context) {
         const filePath = `src/chapters/${chapterSlug}/index.md`;
         let existingLatitude = '';
         let existingLongitude = '';
+        let existingDiscordChannelId = '';
+        let existingDiscordGuildId = '';
         try {
           const { data } = await octokit.repos.getContent({
             owner: repoOwner, repo: repoName, path: filePath, ref: 'main'
@@ -105,8 +107,12 @@ module.exports = async function (request, context) {
           const fileContent = Buffer.from(data.content, 'base64').toString('utf8');
           const latMatch = fileContent.match(/^latitude:\s*(-?[\d.]+)/m);
           const lngMatch = fileContent.match(/^longitude:\s*(-?[\d.]+)/m);
+          const discordChannelMatch = fileContent.match(/^discord_channel_id:\s*"([^"]*)"/m);
+          const discordGuildMatch = fileContent.match(/^discord_guild_id:\s*"([^"]*)"/m);
           if (latMatch) existingLatitude = latMatch[1];
           if (lngMatch) existingLongitude = lngMatch[1];
+          if (discordChannelMatch) existingDiscordChannelId = discordChannelMatch[1];
+          if (discordGuildMatch) existingDiscordGuildId = discordGuildMatch[1];
         } catch (err) {
           context.log(`Could not get existing file SHA: ${err.message}`);
         }
@@ -115,8 +121,8 @@ module.exports = async function (request, context) {
         const markdown = buildChapterMarkdown({
           city: application.city,
           country: application.country,
-          discordChannelId: application.discordChannelId || '',
-          discordGuildId: application.discordGuildId || '',
+          discordChannelId: application.discordChannelId || existingDiscordChannelId,
+          discordGuildId: application.discordGuildId || existingDiscordGuildId,
           leads: sanitisedLeads,
           latitude: existingLatitude,
           longitude: existingLongitude

--- a/api/tests/octokit-integration.test.js
+++ b/api/tests/octokit-integration.test.js
@@ -12,7 +12,9 @@ const mockCreateDispatchEvent = jest.fn().mockResolvedValue({});
 const mockGetContent = jest.fn().mockResolvedValue({
   data: {
     sha: 'abc123',
-    content: Buffer.from('latitude: -31.95\nlongitude: 115.86\n').toString('base64')
+    content: Buffer.from(
+      'latitude: -31.95\nlongitude: 115.86\ndiscord_channel_id: "existing-channel"\ndiscord_guild_id: "existing-guild"\n'
+    ).toString('base64')
   }
 });
 const mockCreateOrUpdateFileContents = jest.fn().mockResolvedValue({});
@@ -496,6 +498,24 @@ describe('updateChapter — automated PR dispatch integration', () => {
     expect(decoded).toContain('layout:');
     expect(decoded).toContain('latitude: -31.95');
     expect(decoded).not.toContain('alice@test.com');
+  });
+
+  test('preserves existing Discord identifiers when storage fields are empty', async () => {
+    storage.getApprovedApplicationBySlug.mockResolvedValueOnce({
+      city: 'Perth',
+      country: 'Australia',
+      email: 'admin@test.com',
+      discordChannelId: '',
+      discordGuildId: ''
+    });
+    setGitHubEnv();
+
+    await updateChapter(makeAuthRequest('POST', validLeads, ['admin']), context);
+
+    const payload = mockCreateDispatchEvent.mock.calls[0][0].client_payload;
+    const decoded = Buffer.from(payload.chapter_markdown_base64, 'base64').toString('utf-8');
+    expect(decoded).toContain('discord_channel_id: "existing-channel"');
+    expect(decoded).toContain('discord_guild_id: "existing-guild"');
   });
 
   test('skips GitHub update when env vars are missing', async () => {

--- a/src/chapters/melbourne/index.md
+++ b/src/chapters/melbourne/index.md
@@ -6,7 +6,7 @@ country: "Australia"
 latitude: -37.8142454
 longitude: 144.9631732
 tags: chapter
-discord_channel_id: ""
+discord_channel_id: "1531283264944340992"
 discord_guild_id: ""
 leads:
   - name: "Santhoshkumar Anandakrishnan"


### PR DESCRIPTION
Portal chapter edits could clear Discord identifiers when the application record did not contain them, even though the existing chapter page did. This caused Melbourne's channel ID to be removed by an otherwise valid lead update.

This change preserves the existing page's Discord channel and guild IDs whenever storage values are blank, adds regression coverage, and restores Melbourne's channel ID while retaining the latest lead details.