### PR TITLE
Fix volunteer badge issuance

### DIFF
--- a/api/src/functions/issueBadges.js
+++ b/api/src/functions/issueBadges.js
@@ -2,6 +2,7 @@ const { createHash } = require('crypto');
 const { getAuthUser, hasRole, unauthorised, forbidden, verifyChapterAccess } = require('../helpers/auth');
 const { getRegistrationsByEvent, getEvent, storeBadge, deleteBadge, getBadgesByEvent } = require('../helpers/tableStorage');
 const { generateSharedEventBadgePng } = require('../helpers/badgeGenerator');
+const { badgeTypeForRole } = require('../helpers/postEventCommunication');
 const { downloadGeneratedImage } = require('../helpers/imageGenerator');
 const { sendBadgeEmail } = require('../helpers/emailService');
 const { logAudit } = require('../helpers/auditLog');
@@ -78,6 +79,7 @@ module.exports = async function (request, context) {
 
     // Download the finalized shared badge variants from private Blob Storage.
     let attendeeBadgeBuffer = null;
+    let volunteerBadgeBuffer = null;
     let speakerBadgeBuffer = null;
     let organiserBadgeBuffer = null;
     if (event.badgeImageUrl) {
@@ -90,6 +92,11 @@ module.exports = async function (request, context) {
         speakerBadgeBuffer = await downloadGeneratedImage(event.speakerBadgeImageUrl);
       } catch (e) { context.log(`Could not fetch speaker badge: ${e.message}`); }
     }
+    if (event.volunteerBadgeImageUrl) {
+      try {
+        volunteerBadgeBuffer = await downloadGeneratedImage(event.volunteerBadgeImageUrl);
+      } catch (e) { context.log(`Could not fetch volunteer badge: ${e.message}`); }
+    }
     if (event.organiserBadgeImageUrl) {
       try {
         organiserBadgeBuffer = await downloadGeneratedImage(event.organiserBadgeImageUrl);
@@ -100,6 +107,12 @@ module.exports = async function (request, context) {
       eventDate: event.date,
       eventLocation: event.location,
       badgeType: 'Attendee'
+    }, null);
+    volunteerBadgeBuffer = volunteerBadgeBuffer || await generateSharedEventBadgePng({
+      eventTitle: event.title,
+      eventDate: event.date,
+      eventLocation: event.location,
+      badgeType: 'Volunteer'
     }, null);
     speakerBadgeBuffer = speakerBadgeBuffer || await generateSharedEventBadgePng({
       eventTitle: event.title,
@@ -115,8 +128,10 @@ module.exports = async function (request, context) {
     }, null);
 
     for (const reg of batch) {
-      const badgeType = reg.role === 'speaker' ? 'Speaker' : reg.role === 'organiser' ? 'Organiser' : 'Attendee';
-      const badgeBuffer = badgeType === 'Speaker'
+      const badgeType = badgeTypeForRole(reg.role);
+      const badgeBuffer = badgeType === 'Volunteer'
+        ? volunteerBadgeBuffer
+        : badgeType === 'Speaker'
         ? speakerBadgeBuffer
         : badgeType === 'Organiser'
           ? organiserBadgeBuffer

--- a/api/src/functions/postEventCommunication.js
+++ b/api/src/functions/postEventCommunication.js
@@ -389,10 +389,11 @@ async function loadBadgeBuffers(event, context) {
   const buffers = {};
   const storedUrls = {
     Attendee: event.badgeImageUrl,
+    Volunteer: event.volunteerBadgeImageUrl,
     Speaker: event.speakerBadgeImageUrl,
     Organiser: event.organiserBadgeImageUrl
   };
-  for (const badgeType of ['Attendee', 'Speaker', 'Organiser']) {
+  for (const badgeType of ['Attendee', 'Volunteer', 'Speaker', 'Organiser']) {
     if (storedUrls[badgeType]) {
       try {
         buffers[badgeType] = await downloadGeneratedImage(storedUrls[badgeType]);

--- a/api/src/functions/regenerateImage.js
+++ b/api/src/functions/regenerateImage.js
@@ -55,12 +55,14 @@ module.exports = async function (request, context) {
     );
     await updateEvent(chapterSlug, eventId, {
       badgeImageUrl: artwork.attendeeImageUrl,
+      volunteerBadgeImageUrl: artwork.volunteerImageUrl,
       speakerBadgeImageUrl: artwork.speakerImageUrl,
       organiserBadgeImageUrl: artwork.organiserImageUrl
     });
 
-    const [attendeeBuffer, speakerBuffer, organiserBuffer] = await Promise.all([
+    const [attendeeBuffer, volunteerBuffer, speakerBuffer, organiserBuffer] = await Promise.all([
       downloadGeneratedImage(artwork.attendeeImageUrl),
+      downloadGeneratedImage(artwork.volunteerImageUrl),
       downloadGeneratedImage(artwork.speakerImageUrl),
       downloadGeneratedImage(artwork.organiserImageUrl)
     ]);
@@ -71,6 +73,7 @@ module.exports = async function (request, context) {
       jsonBody: {
         success: true,
         attendeeImageDataUrl: `data:image/png;base64,${attendeeBuffer.toString('base64')}`,
+        volunteerImageDataUrl: `data:image/png;base64,${volunteerBuffer.toString('base64')}`,
         speakerImageDataUrl: `data:image/png;base64,${speakerBuffer.toString('base64')}`,
         organiserImageDataUrl: `data:image/png;base64,${organiserBuffer.toString('base64')}`,
         themeYear: artwork.themeYear,

--- a/api/src/helpers/badgeGenerator.js
+++ b/api/src/helpers/badgeGenerator.js
@@ -116,14 +116,17 @@ async function generateSharedEventBadgePng({ eventTitle, eventDate, eventLocatio
   const title = escSvg(truncate(eventTitle, 42));
   const date = escSvg(truncate(eventDate, 30));
   const location = escSvg(truncate(eventLocation, 35));
+  const isVolunteer = badgeType === 'Volunteer';
   const isSpeaker = badgeType === 'Speaker';
   const isOrganiser = badgeType === 'Organiser';
-  const isCeremonial = isSpeaker || isOrganiser;
-  const label = isSpeaker ? 'SPEAKER' : isOrganiser ? 'ORGANISER' : 'ATTENDEE';
-  const accent = isSpeaker ? '#f0a52b' : isOrganiser ? '#dc3545' : '#20b2aa';
-  const labelWidth = isSpeaker ? 155 : isOrganiser ? 185 : 170;
+  const isCeremonial = isVolunteer || isSpeaker || isOrganiser;
+  const label = isVolunteer ? 'VOLUNTEER' : isSpeaker ? 'SPEAKER' : isOrganiser ? 'ORGANISER' : 'ATTENDEE';
+  const accent = isVolunteer || isSpeaker ? '#f0a52b' : isOrganiser ? '#dc3545' : '#20b2aa';
+  const labelWidth = isVolunteer ? 190 : isSpeaker ? 155 : isOrganiser ? 185 : 170;
   const footer = isSpeaker
     ? 'Thank you for sharing your expertise with the community · globalsecurity.community'
+    : isVolunteer
+      ? 'Thank you for your time and service to the community · globalsecurity.community'
     : isOrganiser
       ? 'Thank you for your leadership and service to the community · globalsecurity.community'
       : 'Thank you for being part of the community · globalsecurity.community';
@@ -134,7 +137,7 @@ async function generateSharedEventBadgePng({ eventTitle, eventDate, eventLocatio
     <rect y="656" width="1024" height="${isCeremonial ? 7 : 4}" fill="${accent}"/>
     <text x="60" y="715" font-family="system-ui, -apple-system, sans-serif" font-size="18" fill="#aab8c5" letter-spacing="3" font-weight="600">GLOBAL SECURITY COMMUNITY</text>
     <rect x="60" y="740" width="${labelWidth}" height="40" rx="20" fill="${accent}"/>
-    <text x="82" y="767" font-family="system-ui, -apple-system, sans-serif" font-size="18" fill="${isSpeaker ? '#001f3f' : 'white'}" font-weight="bold">${label}</text>
+    <text x="82" y="767" font-family="system-ui, -apple-system, sans-serif" font-size="18" fill="${isSpeaker || isVolunteer ? '#001f3f' : 'white'}" font-weight="bold">${label}</text>
     <text x="60" y="835" font-family="system-ui, -apple-system, sans-serif" font-size="42" fill="white" font-weight="bold">${title}</text>
     <line x1="60" y1="865" x2="964" y2="865" stroke="${accent}" stroke-width="${isCeremonial ? 3 : 2}" opacity="0.7"/>
     <text x="60" y="915" font-family="system-ui, -apple-system, sans-serif" font-size="22" fill="#d9e2ea">${date}</text>

--- a/api/src/helpers/imageGenerator.js
+++ b/api/src/helpers/imageGenerator.js
@@ -336,6 +336,10 @@ async function generateEventBadgeBackground(eventTitle, city, chapterSlug, slug,
     ...badgeDetails,
     badgeType: 'Attendee'
   }, generatedArtwork);
+  const volunteerBuffer = await generateSharedEventBadgePng({
+    ...badgeDetails,
+    badgeType: 'Volunteer'
+  }, generatedArtwork);
   const speakerBuffer = await generateSharedEventBadgePng({
     ...badgeDetails,
     badgeType: 'Speaker'
@@ -346,10 +350,12 @@ async function generateEventBadgeBackground(eventTitle, city, chapterSlug, slug,
   }, generatedArtwork);
   const safeSlug = slug || 'event';
   const attendeeImageUrl = await uploadToBlob(attendeeBuffer, `events/${safeSlug}-attendee.png`, context);
+  const volunteerImageUrl = await uploadToBlob(volunteerBuffer, `events/${safeSlug}-volunteer.png`, context);
   const speakerImageUrl = await uploadToBlob(speakerBuffer, `events/${safeSlug}-speaker.png`, context);
   const organiserImageUrl = await uploadToBlob(organiserBuffer, `events/${safeSlug}-organiser.png`, context);
   return {
     attendeeImageUrl,
+    volunteerImageUrl,
     speakerImageUrl,
     organiserImageUrl,
     themeYear,

--- a/api/src/helpers/postEventCommunication.js
+++ b/api/src/helpers/postEventCommunication.js
@@ -44,6 +44,7 @@ function normaliseRole(role) {
 }
 
 function badgeTypeForRole(role) {
+  if (role === 'volunteer') return 'Volunteer';
   if (role === 'speaker') return 'Speaker';
   if (role === 'organiser') return 'Organiser';
   return 'Attendee';

--- a/api/tests/badgeGenerator.test.js
+++ b/api/tests/badgeGenerator.test.js
@@ -69,16 +69,19 @@ describe('badgeGenerator', () => {
       eventDate: baseOpts.eventDate,
       eventLocation: baseOpts.eventLocation
     };
-    const [attendee, speaker, organiser] = await Promise.all([
+    const [attendee, volunteer, speaker, organiser] = await Promise.all([
       generateSharedEventBadgePng({ ...details, badgeType: 'Attendee' }, null),
+      generateSharedEventBadgePng({ ...details, badgeType: 'Volunteer' }, null),
       generateSharedEventBadgePng({ ...details, badgeType: 'Speaker' }, null),
       generateSharedEventBadgePng({ ...details, badgeType: 'Organiser' }, null)
     ]);
 
     expect(attendee.equals(speaker)).toBe(false);
+    expect(attendee.equals(volunteer)).toBe(false);
     expect(speaker.equals(organiser)).toBe(false);
     await expect(sharp(attendee).metadata()).resolves.toMatchObject({ width: 1024, height: 1024, format: 'png' });
     await expect(sharp(speaker).metadata()).resolves.toMatchObject({ width: 1024, height: 1024, format: 'png' });
+    await expect(sharp(volunteer).metadata()).resolves.toMatchObject({ width: 1024, height: 1024, format: 'png' });
     await expect(sharp(organiser).metadata()).resolves.toMatchObject({ width: 1024, height: 1024, format: 'png' });
   });
 });

--- a/api/tests/functions-coverage.test.js
+++ b/api/tests/functions-coverage.test.js
@@ -97,6 +97,7 @@ jest.mock('../src/helpers/imageGenerator', () => ({
   generateChapterShield: jest.fn().mockResolvedValue('https://gsccoresa.blob.core.windows.net/generated-images/chapters/test-shield.png'),
   generateEventBadgeBackground: jest.fn().mockResolvedValue({
     attendeeImageUrl: 'https://gsccoresa.blob.core.windows.net/generated-images/events/test-attendee.png',
+    volunteerImageUrl: 'https://gsccoresa.blob.core.windows.net/generated-images/events/test-volunteer.png',
     speakerImageUrl: 'https://gsccoresa.blob.core.windows.net/generated-images/events/test-speaker.png',
     organiserImageUrl: 'https://gsccoresa.blob.core.windows.net/generated-images/events/test-organiser.png',
     themeYear: 2026,
@@ -1077,6 +1078,7 @@ describe('issueBadges function', () => {
     storage.getBadgesByEvent.mockResolvedValueOnce([]);
     storage.getRegistrationsByEvent.mockResolvedValueOnce([
       { rowKey: 'r1', fullName: 'Alice', email: 'alice@test.com', checkedIn: true, role: 'attendee', userId: 'u1' },
+      { rowKey: 'r5', fullName: 'Vera', email: 'vera@test.com', checkedIn: true, role: 'volunteer', userId: 'u5' },
       { rowKey: 'r2', fullName: 'Bob', email: 'bob@test.com', checkedIn: true, role: 'speaker', userId: 'u2' },
       { rowKey: 'r4', fullName: 'Dana', email: 'dana@test.com', checkedIn: true, role: 'organiser', userId: 'u4' },
       { rowKey: 'r3', fullName: 'Charlie', email: 'c@test.com', checkedIn: false }
@@ -1084,10 +1086,19 @@ describe('issueBadges function', () => {
     const res = await issueBadges(makeAuthRequest('POST', { eventId: 'ev-1', chapterSlug: 'perth' }, ['admin']), context);
     expect(res.status).toBe(200);
     const body = JSON.parse(res.body);
-    expect(body.issued).toBe(3);
-    expect(body.total).toBe(3);
-    expect(storage.storeBadge).toHaveBeenCalledTimes(3);
-    expect(emailService.sendBadgeEmail).toHaveBeenCalledTimes(3);
+    expect(body.issued).toBe(4);
+    expect(body.total).toBe(4);
+    expect(storage.storeBadge).toHaveBeenCalledTimes(4);
+    expect(emailService.sendBadgeEmail).toHaveBeenCalledTimes(4);
+    expect(emailService.sendBadgeEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'vera@test.com' }),
+      expect.any(String),
+      expect.any(Object),
+      'Volunteer',
+      context,
+      'image/png',
+      'gsc-volunteer-badge.png'
+    );
     expect(emailService.sendBadgeEmail).toHaveBeenCalledWith(
       expect.objectContaining({ email: 'bob@test.com' }),
       expect.any(String),
@@ -1692,6 +1703,7 @@ describe('regenerateImage function', () => {
     expect(res.jsonBody.attendeeImageDataUrl).toBe(`data:image/png;base64,${Buffer.from('generated-image').toString('base64')}`);
     expect(res.jsonBody.speakerImageDataUrl).toBe(`data:image/png;base64,${Buffer.from('generated-image').toString('base64')}`);
     expect(res.jsonBody.organiserImageDataUrl).toBe(`data:image/png;base64,${Buffer.from('generated-image').toString('base64')}`);
+    expect(res.jsonBody.volunteerImageDataUrl).toBe(`data:image/png;base64,${Buffer.from('generated-image').toString('base64')}`);
     expect(res.jsonBody).toMatchObject({
       themeYear: 2026,
       themeCreated: true,
@@ -1707,6 +1719,7 @@ describe('regenerateImage function', () => {
     );
     expect(storage.updateEvent).toHaveBeenCalledWith('perth', 'ev-1', {
       badgeImageUrl: 'https://gsccoresa.blob.core.windows.net/generated-images/events/test-attendee.png',
+      volunteerBadgeImageUrl: 'https://gsccoresa.blob.core.windows.net/generated-images/events/test-volunteer.png',
       speakerBadgeImageUrl: 'https://gsccoresa.blob.core.windows.net/generated-images/events/test-speaker.png',
       organiserBadgeImageUrl: 'https://gsccoresa.blob.core.windows.net/generated-images/events/test-organiser.png'
     });

--- a/api/tests/postEventCommunication.test.js
+++ b/api/tests/postEventCommunication.test.js
@@ -135,6 +135,7 @@ const {
   formatEventDate,
   renderTemplate,
   summariseRecipients,
+  badgeTypeForRole,
   validateTemplates
 } = require('../src/helpers/postEventCommunication');
 
@@ -160,6 +161,10 @@ function request(method, body, query = '') {
 const context = { log: jest.fn() };
 
 describe('post-event communication helpers', () => {
+  test('maps volunteers to Volunteer badges', () => {
+    expect(badgeTypeForRole('volunteer')).toBe('Volunteer');
+    expect(badgeTypeForRole('attendee')).toBe('Attendee');
+  });
   test('summarises only checked-in recipients and deduplicates email addresses', () => {
     expect(summariseRecipients([
       { email: 'one@example.com', checkedIn: true, role: 'speaker' },

--- a/src/js/dashboard.js
+++ b/src/js/dashboard.js
@@ -691,6 +691,7 @@
       preview.innerHTML =
         '<div class="badge-artwork-preview-grid">' +
           '<figure><img src="' + GSC.esc(data.attendeeImageDataUrl) + '" alt="Generated attendee badge artwork" class="badge-artwork-preview"><figcaption>Attendee</figcaption></figure>' +
+          '<figure><img src="' + GSC.esc(data.volunteerImageDataUrl) + '" alt="Generated volunteer badge artwork" class="badge-artwork-preview"><figcaption>Volunteer</figcaption></figure>' +
           '<figure><img src="' + GSC.esc(data.speakerImageDataUrl) + '" alt="Generated speaker badge artwork" class="badge-artwork-preview"><figcaption>Speaker</figcaption></figure>' +
           '<figure><img src="' + GSC.esc(data.organiserImageDataUrl) + '" alt="Generated organiser badge artwork" class="badge-artwork-preview"><figcaption>Organiser</figcaption></figure>' +
         '</div>';


### PR DESCRIPTION
Volunteers were correctly stored and checked in with the `volunteer` role, but both badge delivery paths silently mapped that role to Attendee. This caused all nine checked-in volunteers at Global Security Bootcamp Perth 2026 to receive the wrong badge.

This change adds Volunteer as a first-class badge variant across role mapping, artwork generation and storage, post-event communication, direct badge issuance, and dashboard previews. Existing attendee, speaker, and organiser behavior remains unchanged.

Tests cover volunteer role mapping, issuance, generated artwork, and event artwork persistence. The full API suite passes with 343 tests.